### PR TITLE
New features introduced: hide empty brackets, alternative search result

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+Initial commit - prepare Attachments plugin to work with Joomla 4.
+

--- a/attachments_component/admin/config.xml
+++ b/attachments_component/admin/config.xml
@@ -65,6 +65,13 @@
       <option value="1">JYES</option>
       <option value="0">JNO</option>
     </field>
+    <field name="hide_brackets_if_empty" type="radio" default="0" class="btn-group"
+           label="ATTACH_HIDE_BRACKETS_IF_EMPTY"
+           description="ATTACH_HIDE_BRACKETS_IF_EMPTY_DESCRIPTION">
+      <option value="1">JYES</option>
+      <option value="0">JNO</option>
+    </field>
+
     <field name="show_creator_name" type="radio" default="0" class="btn-group"
            label="ATTACH_SHOW_ATTACHMENT_CREATOR"
            description="ATTACH_SHOW_ATTACHMENT_CREATOR_DESCRIPTION">
@@ -224,7 +231,12 @@
            label="ATTACH_URL_TO_REGISTER" size="65"
            description="ATTACH_URL_TO_REGISTER_DESCRIPTION">
     </field>
-
+    <field name="alternative_search_results" type="radio" default="0" class="btn-group"
+           label="ATTACH_ALTERNATIVE_SEARCH_RESULTS"
+           description="ATTACH_ALTERNATIVE_SEARCH_RESULTS_DESC">
+      <option value="1">JYES</option>
+      <option value="0">JNO</option>
+    </field>
   </fieldset>
 
   <fieldset name="security"

--- a/attachments_component/admin/language/en-GB/en-GB.com_attachments.ini
+++ b/attachments_component/admin/language/en-GB/en-GB.com_attachments.ini
@@ -378,3 +378,8 @@ COM_ATTACHMENTS_N_ITEMS_PUBLISHED="%d Attachments successfully published"
 COM_ATTACHMENTS_N_ITEMS_PUBLISHED_1="Attachment successfully published"
 COM_ATTACHMENTS_N_ITEMS_UNPUBLISHED="%d Attachments successfully unpublished"
 COM_ATTACHMENTS_N_ITEMS_UNPUBLISHED_1="Attachment successfully unpublished"
+
+ATTACH_ALTERNATIVE_SEARCH_RESULTS="Alternative search results format"
+ATTACH_ALTERNATIVE_SEARCH_RESULTS_DESC="Switch to alternative search results format for searching attachments - create links to content to which attachment is connected, keep attachment detail information in result" 
+ATTACH_HIDE_BRACKETS_IF_EMPTY="Hide brackets when empty"
+ATTACH_HIDE_BRACKETS_IF_EMPTY_DESCRIPTION="Hide brackets when there is no value in 'description' or user defined fields"

--- a/attachments_component/site/views/attachments/tmpl/default.php
+++ b/attachments_component/site/views/attachments/tmpl/default.php
@@ -222,41 +222,68 @@ for ($i=0, $n=count($attachments); $i < $n; $i++) {
 	// Add description (maybe)
 	if ( $this->show_description ) {
 		$description = htmlspecialchars(stripslashes($attachment->description));
-		if ( JString::strlen($description) == 0)
+        $is_empty = 0;
+		if ( JString::strlen($description) == 0) {			
 			$description = '&nbsp;';
+			$is_empty = 1;			
+		}
+		
 		if ( $this->show_column_titles )
 			$html .= "<td class=\"at_description\">$description</td>";
 		else
-			$html .= "<td class=\"at_description\">[$description]</td>";
+			if ($is_empty && $this->params->get('hide_brackets_if_empty')) 
+				$html .= "<td class=\"at_description\">$description</td>";
+			else
+				$html .= "<td class=\"at_description\">[$description]</td>";		
 		}
 
 	// Show the USER DEFINED FIELDs (maybe)
 	if ( $this->show_user_field_1 ) {
 		$user_field = stripslashes($attachment->user_field_1);
-		if ( JString::strlen($user_field) == 0 )
+	    $is_empty = 0;
+		if ( JString::strlen($user_field) == 0 ) {
 			$user_field = '&nbsp;';
+			$is_empty = 1;			
+		}
+
 		if ( $this->show_column_titles )
 			$html .= "<td class=\"at_user_field\">" . $user_field . "</td>";
 		else
-			$html .= "<td class=\"at_user_field\">[" . $user_field . "]</td>";
+			if ($is_empty && $this->params->get('hide_brackets_if_empty')) 
+				$html .= "<td class=\"at_user_field\">" . $user_field . "</td>";
+			else
+				$html .= "<td class=\"at_user_field\">[" . $user_field . "]</td>";
 		}
 	if ( $this->show_user_field_2 ) {
 		$user_field = stripslashes($attachment->user_field_2);
-		if ( JString::strlen($user_field) == 0 )
+		if ( JString::strlen($user_field) == 0 ) {
 			$user_field = '&nbsp;';
+			$is_empty = 1;			
+		}
+
 		if ( $this->show_column_titles )
 			$html .= "<td class=\"at_user_field\">" . $user_field . "</td>";
 		else
-			$html .= "<td class=\"at_user_field\">[" . $user_field . "]</td>";
+			if ($is_empty && $this->params->get('hide_brackets_if_empty')) 
+				$html .= "<td class=\"at_user_field\">" . $user_field . "</td>";
+			else
+				$html .= "<td class=\"at_user_field\">[" . $user_field . "]</td>";
 		}
 	if ( $this->show_user_field_3 ) {
 		$user_field = stripslashes($attachment->user_field_3);
-		if ( JString::strlen($user_field) == 0 )
+	    $is_empty = 0;
+		if ( JString::strlen($user_field) == 0 ) {
 			$user_field = '&nbsp;';
+			$is_empty = 1;			
+		}
+
 		if ( $this->show_column_titles )
 			$html .= "<td class=\"at_user_field\">" . $user_field . "</td>";
 		else
-			$html .= "<td class=\"at_user_field\">[" . $user_field . "]</td>";
+			if ($is_empty && $this->params->get('hide_brackets_if_empty')) 
+				$html .= "<td class=\"at_user_field\">" . $user_field . "</td>";
+			else
+				$html .= "<td class=\"at_user_field\">[" . $user_field . "]</td>";
 		}
 
 	// Add the creator's username (if requested)


### PR DESCRIPTION
This fork introduce:
1. Option to hide 'unnecessary' bracket chars [] when 'description' field and user defined fields are empty,
2. Clickable search result titles that links to content to which attachment was attached, rather than to file/url itself, both article and/or category.

Both options are added to config.xml, default off.

ps. if i did everything correct this should work out of the box - i'm new to this github thing ;)
