### PR TITLE
Adapt for joomla 5 + iframe size for add attachmets and delete attachements + versions for 4.0.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION = "3.2.6"
+VERSION = "4.0.1"
 VERSION2 = $(shell echo $(VERSION)|sed 's/ /-/g')
 ZIPFILE = attachments-$(VERSION2).zip
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# attachments 4.0 (beta version)
+# attachments 4.0.1
 
 This branch is in test. Adapting the component to work with Joomla 4.
 
@@ -8,7 +8,16 @@ Download <a href="https://github.com/jmcameron/attachments/releases/latest" targ
 
 ## Requirements
 
-Joomla 4.0+
+Joomla 4.0+ compatible also with Joomla 5.0+
+
+## Changes since 4.0 beta
+
+orrection for Blank page in popup after adding file #41
+Show attachments for blog articles issue #40
+Add scrollbar to iframes
+Fix modal not closing
+The Event::getArguments changed in Joomla 5
+Reorganize code to work with both joomla 4 and 5
 
 ## Migration from attachments 3
 - make backup

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Joomla 4.0+ compatible also with Joomla 5.0+
 
 ## Changes since 4.0 beta
 
-orrection for Blank page in popup after adding file #41
+correction for Blank page in popup after adding file #41
 Show attachments for blog articles issue #40
 Add scrollbar to iframes
 Fix modal not closing

--- a/add_attachment_btn_plugin/add_attachment.xml
+++ b/add_attachment_btn_plugin/add_attachment.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="editors-xtd" version="4.0" method="upgrade">
     <name>plg_editors-xtd_add_attachment_btn</name>
-    <version>4.0.0</version>
+    <version>4.0.1</version>
     <creationDate>January 1, 2024</creationDate>
     <author>Jonathan M. Cameron</author>
     <copyright>(C) 2007-2024 Jonathan M. Cameron. All rights reserved.</copyright>

--- a/attachments_component/attachments.xml
+++ b/attachments_component/attachments.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="component" version="4.0" method="upgrade">
     <name>com_attachments</name>
-    <version>4.0.0</version>
+    <version>4.0.1</version>
     <creationDate>January 1, 2024</creationDate>
     <author>Jonathan M. Cameron</author>
     <authorEmail>jmcameron@jmcameron.net</authorEmail>

--- a/attachments_component/site/src/Helper/AttachmentsHelper.php
+++ b/attachments_component/site/src/Helper/AttachmentsHelper.php
@@ -620,8 +620,12 @@ class AttachmentsHelper
 		// Make sure the file type is okay (respect restrictions imposed by media manager)
 		$cmparams = ComponentHelper::getParams('com_media');
 
-		// Check to make sure the extension is allowed
-		$allowable = explode( ',', $cmparams->get( 'restrict_uploads_extensions' ) ?? '');
+		// Check to make sure the extension is allowed in Joomla 5 it was renamed
+		if (version_compare(JVERSION, '5', 'lt')) {
+			$allowable = explode( ',', $cmparams->get( 'restrict_uploads_extensions' ) ?? '');
+		} else {
+			$allowable = explode( ',', $cmparams->get( 'upload_extensions' ) ?? '');
+		}
 		$ignored = explode(',', $cmparams->get( 'ignore_extensions' ) ?? '');
 		$extension = StringHelper::strtolower(File::getExt($filename));
 		$error = false;
@@ -1922,7 +1926,7 @@ class AttachmentsHelper
 			'libraries.html.bootstrap.modal.main', 
 			[
 				'selector' => 'modal-' . $randomId, 
-				'body' => "<iframe src=\"$url\" scrolling=\"yes\" loading=\"lazy\"></iframe>",
+				'body' => "<iframe width=\"100%\" height=\"600\" src=\"$url\" scrolling=\"auto\" loading=\"lazy\"></iframe>",
 				'params' => $modalParams
 			]
 		);

--- a/attachments_component/site/src/Helper/AttachmentsHelper.php
+++ b/attachments_component/site/src/Helper/AttachmentsHelper.php
@@ -620,12 +620,8 @@ class AttachmentsHelper
 		// Make sure the file type is okay (respect restrictions imposed by media manager)
 		$cmparams = ComponentHelper::getParams('com_media');
 
-		// Check to make sure the extension is allowed in Joomla 5 it was renamed
-		if (version_compare(JVERSION, '5', 'lt')) {
-			$allowable = explode( ',', $cmparams->get( 'restrict_uploads_extensions' ) ?? '');
-		} else {
-			$allowable = explode( ',', $cmparams->get( 'upload_extensions' ) ?? '');
-		}
+		// Check to make sure the extension is allowed
+		$allowable = explode( ',', $cmparams->get( 'restrict_uploads_extensions' ) ?? '');
 		$ignored = explode(',', $cmparams->get( 'ignore_extensions' ) ?? '');
 		$extension = StringHelper::strtolower(File::getExt($filename));
 		$error = false;

--- a/attachments_component/site/tmpl/attachments/default.php
+++ b/attachments_component/site/tmpl/attachments/default.php
@@ -359,7 +359,7 @@ for ($i=0, $n=count($attachments); $i < $n; $i++) {
 			'libraries.html.bootstrap.modal.main', 
 			[
 				'selector' => 'modal-' . $randomId, 
-				'body' => "<iframe src=\"$delete_url\" scrolling=\"yes\" loading=\"lazy\"></iframe>",
+				'body' => "<iframe width=\"100%\" height=\"200\" src=\"$delete_url\" scrolling=\"yes\" loading=\"lazy\"></iframe>",
 				'params' => $modalParams
 			]
 		);

--- a/attachments_plugin/attachments.xml
+++ b/attachments_plugin/attachments.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="content" version="4.0" method="upgrade">
     <name>plg_content_attachments</name>
-    <version>4.0.0</version>
+    <version>4.0.1</version>
     <creationDate>January 1, 2024</creationDate>
     <author>Jonathan M. Cameron</author>
     <authorEmail>jmcameron@jmcameron.net</authorEmail>

--- a/pkg_attachments/pkg_attachments.xml
+++ b/pkg_attachments/pkg_attachments.xml
@@ -2,9 +2,9 @@
 <extension type="package" version="4.0" method="upgrade">
     <name>pkg_attachments</name>
     <packagename>attachments</packagename>
-    <version>3.2.6</version>
-    <creationDate>March 26, 2018</creationDate>
-    <copyright>(C) 2007-2018 Jonathan M. Cameron. All rights reserved.</copyright>
+    <version>4.0.1</version>
+    <creationDate>January 1, 2024</creationDate>
+    <copyright>(C) 2007-2024 Jonathan M. Cameron. All rights reserved.</copyright>
     <license>http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL</license>
     <author>Jonathan M. Cameron</author>
     <authorEmail>jmcameron@jmcameron.net</authorEmail>

--- a/show_attachments_in_editor_plugin/show_attachments.xml
+++ b/show_attachments_in_editor_plugin/show_attachments.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="system" version="4.0" method="upgrade">
     <name>plg_system_show_attachments_in_editor</name>
-    <version>3.2.6</version>
-    <creationDate>March 26, 2018</creationDate>
+    <version>4.0.0</version>
+    <creationDate>January 1, 2024</creationDate>
     <author>Jonathan M. Cameron</author>
-    <copyright>(C) 2011-2018 Jonathan M. Cameron. All rights reserved.</copyright>
+    <copyright>(C) 2011-2024 Jonathan M. Cameron. All rights reserved.</copyright>
     <license>http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL</license>
     <authorEmail>jmcameron@jmcameron.net</authorEmail>
     <authorUrl>http://joomlacode.org/gf/project/attachments/</authorUrl>


### PR DESCRIPTION
- adapt iframe size . 
At least it corrects ssize in jomomla5
- adapt check of media type : in joomla 5 the field has been renamed
- update versions numbers for all parts that has been update since 4.0.0

@parapente  could you please check this pull request so that we can merge and provide a release version 4.09.1
 