### PR TITLE
Fix plugin warnings

### DIFF
--- a/add_attachment_btn_plugin/services/provider.php
+++ b/add_attachment_btn_plugin/services/provider.php
@@ -25,8 +25,9 @@ return new class () implements ServiceProviderInterface {
         $container->set(
             PluginInterface::class,
             function (Container $container) {
+                $dispatcher = $container->get(DispatcherInterface::class);
                 $plugin     = new AddAttachment(
-                    $container->get(DispatcherInterface::class),
+                    $dispatcher,
                     (array) PluginHelper::getPlugin('editors-xtd', 'add_attachment')
                 );
                 $plugin->setApplication(Factory::getApplication());

--- a/insert_attachments_token_btn_plugin/services/provider.php
+++ b/insert_attachments_token_btn_plugin/services/provider.php
@@ -25,8 +25,9 @@ return new class () implements ServiceProviderInterface {
         $container->set(
             PluginInterface::class,
             function (Container $container) {
+                $dispatcher = $container->get(DispatcherInterface::class);
                 $plugin     = new InsertAttachmentsToken(
-                    $container->get(DispatcherInterface::class),
+                    $dispatcher,
                     (array) PluginHelper::getPlugin('editors-xtd', 'insert_attachments_token')
                 );
                 $plugin->setApplication(Factory::getApplication());


### PR DESCRIPTION
Fix php warnings when creating a new attachment plugin object as dispatcher should be passed by reference. If we use ```$container->get(DispatcherInterface::class)``` php warns that we should use a variable to be passed as reference.