### PR TITLE
Fix attachment parent info saving for Joomla 5 for new articles

### DIFF
--- a/attachments_plugin/attachments.php
+++ b/attachments_plugin/attachments.php
@@ -380,7 +380,14 @@ class PlgContentAttachments extends CMSPlugin implements SubscriberInterface
 	 */
 	function onContentAfterSave(Event $event)
 	{
-		[$context, $item, $isNew] = $event->getArguments();
+		if (version_compare(JVERSION, '5', 'lt')) {
+			[$context, $item, $isNew] = $event->getArguments();
+		} else {
+			$context = $event->getArgument('context');
+			$item = $event->getArgument('subject');
+			$isNew = $event->getArgument('isNew');
+		}
+		
 		if ( !$isNew ) {
 			// If the item is not new, this step is not needed
 			return true;


### PR DESCRIPTION
When you create new articles in Joomla 5 and add attachments, the article info isn't always saved for the attachments. As a result some attachments stay in the `attachments/article/0` folder and they lack article info in the database. When you try to create another new article the same attachments appear in the newly created article.