### PR TITLE
More admin dark mode fixes

### DIFF
--- a/add_attachment_btn_plugin/src/Extension/AddAttachment.php
+++ b/add_attachment_btn_plugin/src/Extension/AddAttachment.php
@@ -178,6 +178,7 @@ class AddAttachment extends CMSPlugin implements SubscriberInterface
 
 		// Add the regular css file
 		HTMLHelper::stylesheet('media/com_attachments/css/attachments_list.css');
+		HTMLHelper::stylesheet('media/com_attachments/css/attachments_list_dark.css');
 		HTMLHelper::stylesheet('media/com_attachments/css/add_attachment_button.css');
 
 		// Handle RTL styling (if necessary)

--- a/attachments_component/attachments.xml
+++ b/attachments_component/attachments.xml
@@ -180,6 +180,7 @@
        <filename>css/attachments_hide.css</filename>
        <filename>css/attachments_help.css</filename>
        <filename>css/attachments_list.css</filename>
+       <filename>css/attachments_list_dark.css</filename>
        <filename>css/attachments_list_rtl.css</filename>
        <filename>css/attachments_quickicon.css</filename>
        <filename>css/insert_attachments_token_button.css</filename>

--- a/attachments_component/media/css/attachments_list_dark.css
+++ b/attachments_component/media/css/attachments_list_dark.css
@@ -1,0 +1,21 @@
+@media (prefers-color-scheme: dark) {
+    div.attachmentsList a.at_url:link {
+        color: #2a69b8;
+    }
+
+    #main div.attachmentsList tbody tr.even,
+    #main div.attachmentsList tbody tr.even td,
+    div.attachmentsList tbody tr.even td,
+    div.attachmentsList tbody tr.even {
+        background-color: rgb(25 29 41);
+    }
+
+    #main div.attachmentsList table tbody tr.even td,
+    div.attachmentsList table tbody tr.even td {
+        background-color: rgb(25 29 41);
+    }
+
+    form.attachmentsBackend+div.attachmentsList table {
+        background-color: unset;
+    }
+}

--- a/attachments_component/site/src/View/Attachments/HtmlView.php
+++ b/attachments_component/site/src/View/Attachments/HtmlView.php
@@ -75,6 +75,7 @@ class HtmlView extends BaseHtmlView
 
 		// if we have attachments, add the stylesheets for the attachments list
 		HTMLHelper::stylesheet('media/com_attachments/css/attachments_list.css');
+		HTMLHelper::stylesheet('media/com_attachments/css/attachments_list_dark.css');
 		$lang = $app->getLanguage();
 		if ( $lang->isRTL() ) {
 			HTMLHelper::stylesheet('media/com_attachments/css/attachments_list_rtl.css');

--- a/attachments_component/site/src/View/AttachmentsFormView.php
+++ b/attachments_component/site/src/View/AttachmentsFormView.php
@@ -65,6 +65,7 @@ class AttachmentsFormView extends HtmlView
 
 		// Add the CSS for the attachments list (whether we need it or not)
 		HTMLHelper::stylesheet('media/com_attachments/css/attachments_list.css');
+		HTMLHelper::stylesheet('media/com_attachments/css/attachments_list_dark.css');
 
 		$head_renderer = new HeadRenderer($document);
 

--- a/attachments_plugin_framework/src/PlgAttachmentsFramework.php
+++ b/attachments_plugin_framework/src/PlgAttachmentsFramework.php
@@ -970,6 +970,7 @@ class PlgAttachmentsFramework extends CMSPlugin implements SubscriberInterface
 		{
 			// Add the style sheet
 			HTMLHelper::stylesheet('media/com_attachments/css/attachments_list.css');
+			HTMLHelper::stylesheet('media/com_attachments/css/attachments_list_dark.css');
 
 			// Handle RTL styling (if necessary)
 			$lang = $this->app->getLanguage();

--- a/insert_attachments_token_btn_plugin/src/Extension/InsertAttachmentsToken.php
+++ b/insert_attachments_token_btn_plugin/src/Extension/InsertAttachmentsToken.php
@@ -145,6 +145,7 @@ class InsertAttachmentsToken extends CMSPlugin implements SubscriberInterface
 
 		// Add the regular css file
 		HTMLHelper::stylesheet('media/com_attachments/css/attachments_list.css');
+		HTMLHelper::stylesheet('media/com_attachments/css/attachments_list_dark.css');
 		HTMLHelper::stylesheet('media/com_attachments/css/insert_attachments_token_button.css');
 
 		// Handle RTL styling (if necessary)


### PR DESCRIPTION
Fixes:
- Add attachment dialog had white background on the list of attachments. In dark mode this made already attached files filenames unreadable
- Attachments that where not published had a very light color for the links which made them difficult to read
- Changed the color of even rows to make them better match the theme