### PR TITLE
Forces the ID to be greater than zero

### DIFF
--- a/attachments_component/site/src/Controller/DisplayController.php
+++ b/attachments_component/site/src/Controller/DisplayController.php
@@ -448,8 +448,8 @@ class DisplayController extends BaseController
 	public function download()
 	{
 		// Get the attachment ID
-		$id = $this->input->getInt('id');
-		if ( !is_numeric($id) ) {
+		$id = $this->input->getInt('id', '0');
+		if ( !is_numeric($id) || $id <=0 ) {
 			$errmsg = Text::sprintf('ATTACH_ERROR_INVALID_ATTACHMENT_ID_N', $id) . ' (ERR 12)';
 			throw new \Exception($errmsg, 500);
 			}


### PR DESCRIPTION
It is safer to verify that the ID is greater than zero before downloading the attachment.
Do not accept IDs with a value of zero or negative before call AttachmentsHelper::download_attachment($id);