### PR TITLE
Fix the order of the options for hiding empty brackets

### DIFF
--- a/attachments_component/admin/config.xml
+++ b/attachments_component/admin/config.xml
@@ -68,8 +68,8 @@
     <field name="hide_brackets_if_empty" type="radio" default="0" layout="joomla.form.field.radio.switcher"
            label="ATTACH_HIDE_BRACKETS_IF_EMPTY"
            description="ATTACH_HIDE_BRACKETS_IF_EMPTY_DESCRIPTION">
-      <option value="1">JYES</option>
       <option value="0">JNO</option>
+      <option value="1">JYES</option>
     </field>
 
     <field name="show_creator_name" type="radio" default="0" layout="joomla.form.field.radio.switcher"


### PR DESCRIPTION
Unfortunately the order of the option tags is important. As it is right now when the switch is green and on the right side the selected option is the one with the NO value. If you change the order it is the YES value. For uniformity we should have all the no and yes values on the same side. It doesn't break any functionality so there is no reason for a new release for now.