### PR TITLE
Check if $attachment_id[$i] exists

### DIFF
--- a/attachments_plugin_framework/src/PlgAttachmentsFramework.php
+++ b/attachments_plugin_framework/src/PlgAttachmentsFramework.php
@@ -962,7 +962,7 @@ class PlgAttachmentsFramework extends CMSPlugin implements SubscriberInterface
 				->getMVCFactory();
 			/** @var \JMCameron\Component\Attachments\Site\Controller\AttachmentsController $controller */
 			$controller		  = $mvc->createController('Attachments', 'Site', [], $this->app, $this->app->getInput());
-			$attachments_list = $controller->displayString($parent_id, $this->parent_type, $parent_entity, null, true, true, false, $from, $attachment_id[$i]);
+			$attachments_list = $controller->displayString($parent_id, $this->parent_type, $parent_entity, null, true, true, false, $from, $attachment_id[$i] ?? null);
 
 			// If the attachments list is empty, insert an empty div for it
 			if ($attachments_list == '')


### PR DESCRIPTION
Fixes a warning that appears on articles that have no attachments