### PR TITLE
Correct Issue #108 :Show a download icon should be available even if download mode is inline

### DIFF
--- a/attachments_component/admin/config.xml
+++ b/attachments_component/admin/config.xml
@@ -259,7 +259,7 @@
     <field name="show_raw_download" type="radio" default="0" layout="joomla.form.field.radio.switcher"
            label="ATTACH_SHOW_RAW_DOWNLOAD"
            description="ATTACH_SHOW_RAW_DOWNLOAD_DESCRIPTION"
-           showon="download_mode:inline[AND]file_link_open_mode:in_a_popup">
+           showon="file_link_open_mode:in_a_popup">
       <option value="0">JNO</option>
       <option value="1">JYES</option>
     </field>


### PR DESCRIPTION
Show a download icon should be available without regarding  download mode value