### PR TITLE
Improve the Fix - Access array offset on value of type null #111

### DIFF
--- a/attachments_plugin_framework/src/PlgAttachmentsFramework.php
+++ b/attachments_plugin_framework/src/PlgAttachmentsFramework.php
@@ -914,7 +914,7 @@ class PlgAttachmentsFramework extends CMSPlugin implements SubscriberInterface
 		$attachments_tag	  = [];
 		$attachments_tag_args = '';
 		$match				  = false;
-		$attachment_id        = null;
+		$attachment_id []     = null;
 		$offset               = -1;
 		while (false != ($offset = StringHelper::strpos($content->$text_field_name, '{attachments', $offset + 1)))
 		{
@@ -962,7 +962,7 @@ class PlgAttachmentsFramework extends CMSPlugin implements SubscriberInterface
 				->getMVCFactory();
 			/** @var \JMCameron\Component\Attachments\Site\Controller\AttachmentsController $controller */
 			$controller		  = $mvc->createController('Attachments', 'Site', [], $this->app, $this->app->getInput());
-			$attachments_list = $controller->displayString($parent_id, $this->parent_type, $parent_entity, null, true, true, false, $from, $attachment_id[$i] ?? null);
+			$attachments_list = $controller->displayString($parent_id, $this->parent_type, $parent_entity, null, true, true, false, $from, $attachment_id[$i]);
 
 			// If the attachments list is empty, insert an empty div for it
 			if ($attachments_list == '')


### PR DESCRIPTION
 Ensures $attachment_id is always an array before being accessed. Eliminates the need for ?? null as a fallback.
See  https://github.com/jmcameron/attachments/issues/111