### PR TITLE
Adding FontAwesome feature - alternative for legacy gif iconss.

### DIFF
--- a/attachments_component/admin/config.xml
+++ b/attachments_component/admin/config.xml
@@ -107,6 +107,21 @@
            label="ATTACH_FORMAT_STRING_FOR_DATES" size="30"
            description="ATTACH_FORMAT_STRING_FOR_DATES_DESCRIPTION">
     </field>
+    <field name="use_fontawesome_icons" type="radio" default="1" class="btn-group"
+           label="ATTACH_SHOW_FONTAWESOME_ICONS"
+           description="ATTACH_SHOW_FONTAWESOME_ICONS_DESCRIPTION">
+      <option value="1">JYES</option>
+      <option value="0">JNO</option>
+    </field>
+    <field name="use_fontawesome_icons_style" type="list" default="fas"
+           label="ATTACH_SHOW_FONTAWESOME_ICONS_STYLE"
+           description="ATTACH_SHOW_FONTAWESOME_ICONS_STYLE_DESCRIPTION"
+           showon="use_fontawesome_icons:1">
+      <option value="fas">ATTACH_SHOW_FONTAWESOME_ICONS_STYLE_FAS</option>
+      <option value="far">ATTACH_SHOW_FONTAWESOME_ICONS_STYLE_FAR</option>
+      <option value="fal">ATTACH_SHOW_FONTAWESOME_ICONS_STYLE_FAL</option>
+      <option value="fad">ATTACH_SHOW_FONTAWESOME_ICONS_STYLE_FAD</option>
+    </field>
     <field name="sort_order" type="list" default="filename"
            label="ATTACH_ATTACHMENTS_LIST_ORDER"
            description="ATTACH_ATTACHMENTS_LIST_ORDER_DESCRIPTION">

--- a/attachments_component/admin/config.xml
+++ b/attachments_component/admin/config.xml
@@ -110,8 +110,8 @@
     <field name="use_fontawesome_icons" type="radio" default="1" class="btn-group"
            label="ATTACH_SHOW_FONTAWESOME_ICONS"
            description="ATTACH_SHOW_FONTAWESOME_ICONS_DESCRIPTION">
-      <option value="0">JNO</option>
-      <option value="1">JYES</option>
+      <option value="1">JNO</option>
+      <option value="0">JYES</option>
     </field>
     <field name="use_fontawesome_icons_style" type="list" default="fas"
            label="ATTACH_SHOW_FONTAWESOME_ICONS_STYLE"

--- a/attachments_component/admin/config.xml
+++ b/attachments_component/admin/config.xml
@@ -110,8 +110,8 @@
     <field name="use_fontawesome_icons" type="radio" default="1" class="btn-group"
            label="ATTACH_SHOW_FONTAWESOME_ICONS"
            description="ATTACH_SHOW_FONTAWESOME_ICONS_DESCRIPTION">
-      <option value="1">JNO</option>
-      <option value="0">JYES</option>
+      <option value="0">JNO</option>
+      <option value="1">JYES</option>
     </field>
     <field name="use_fontawesome_icons_style" type="list" default="fas"
            label="ATTACH_SHOW_FONTAWESOME_ICONS_STYLE"

--- a/attachments_component/admin/config.xml
+++ b/attachments_component/admin/config.xml
@@ -107,11 +107,11 @@
            label="ATTACH_FORMAT_STRING_FOR_DATES" size="30"
            description="ATTACH_FORMAT_STRING_FOR_DATES_DESCRIPTION">
     </field>
-    <field name="use_fontawesome_icons" type="radio" default="1" class="btn-group"
+    <field name="use_fontawesome_icons" type="radio" default="1" layout="joomla.form.field.radio.switcher"
            label="ATTACH_SHOW_FONTAWESOME_ICONS"
            description="ATTACH_SHOW_FONTAWESOME_ICONS_DESCRIPTION">
-      <option value="1">JYES</option>
       <option value="0">JNO</option>
+      <option value="1">JYES</option>
     </field>
     <field name="use_fontawesome_icons_style" type="list" default="fas"
            label="ATTACH_SHOW_FONTAWESOME_ICONS_STYLE"

--- a/attachments_component/admin/config.xml
+++ b/attachments_component/admin/config.xml
@@ -107,7 +107,7 @@
            label="ATTACH_FORMAT_STRING_FOR_DATES" size="30"
            description="ATTACH_FORMAT_STRING_FOR_DATES_DESCRIPTION">
     </field>
-    <field name="use_fontawesome_icons" type="radio" default="1" layout="joomla.form.field.radio.switcher"
+    <field name="use_fontawesome_icons" type="radio" default="0" layout="joomla.form.field.radio.switcher"
            label="ATTACH_SHOW_FONTAWESOME_ICONS"
            description="ATTACH_SHOW_FONTAWESOME_ICONS_DESCRIPTION">
       <option value="0">JNO</option>

--- a/attachments_component/admin/config.xml
+++ b/attachments_component/admin/config.xml
@@ -110,8 +110,8 @@
     <field name="use_fontawesome_icons" type="radio" default="1" class="btn-group"
            label="ATTACH_SHOW_FONTAWESOME_ICONS"
            description="ATTACH_SHOW_FONTAWESOME_ICONS_DESCRIPTION">
-      <option value="1">JNO</option>
-      <option value="0">JYES</option>
+      <option value="1">JYES</option>
+      <option value="0">JNO</option>
     </field>
     <field name="use_fontawesome_icons_style" type="list" default="fas"
            label="ATTACH_SHOW_FONTAWESOME_ICONS_STYLE"

--- a/attachments_component/admin/config.xml
+++ b/attachments_component/admin/config.xml
@@ -110,8 +110,8 @@
     <field name="use_fontawesome_icons" type="radio" default="1" class="btn-group"
            label="ATTACH_SHOW_FONTAWESOME_ICONS"
            description="ATTACH_SHOW_FONTAWESOME_ICONS_DESCRIPTION">
-      <option value="1">JYES</option>
-      <option value="0">JNO</option>
+      <option value="1">JNO</option>
+      <option value="0">JYES</option>
     </field>
     <field name="use_fontawesome_icons_style" type="list" default="fas"
            label="ATTACH_SHOW_FONTAWESOME_ICONS_STYLE"

--- a/attachments_component/admin/language/en-GB/en-GB.com_attachments.ini
+++ b/attachments_component/admin/language/en-GB/en-GB.com_attachments.ini
@@ -389,4 +389,12 @@ COM_ATTACHMENTS_N_ITEMS_PUBLISHED_1="Attachment successfully published"
 COM_ATTACHMENTS_N_ITEMS_UNPUBLISHED="%d Attachments successfully unpublished"
 COM_ATTACHMENTS_N_ITEMS_UNPUBLISHED_1="Attachment successfully unpublished"
 
+ATTACH_SHOW_FONTAWESOME_ICONS="Use FontAwesome icons"
+ATTACH_SHOW_FONTAWESOME_ICONS_DESCRIPTION="Use FontAwesome icons for file types, if set to 'No' legacy icons (gif files) will be used. Attachment 'file icon' value wont be affected by this setting, its purpose is only to visualize file types."
 
+ATTACH_SHOW_FONTAWESOME_ICONS_STYLE="FontAwesome icons style"
+ATTACH_SHOW_FONTAWESOME_ICONS_STYLE_DESCRIPTION="Use specific FontAwesome icons style: solid, regular light or duotone, some require FontAwesome PRO licence."
+ATTACH_SHOW_FONTAWESOME_ICONS_STYLE_FAS="Solid"
+ATTACH_SHOW_FONTAWESOME_ICONS_STYLE_FAR="Regular"
+ATTACH_SHOW_FONTAWESOME_ICONS_STYLE_FAL="Light (FontAwesome PRO only)"
+ATTACH_SHOW_FONTAWESOME_ICONS_STYLE_FAD="Duotone (FontAwesome PRO only)"

--- a/attachments_component/admin/tmpl/attachments/default_body.php
+++ b/attachments_component/admin/tmpl/attachments/default_body.php
@@ -41,21 +41,24 @@ $last_parent_type = null;
 $last_parent_entity = null;
 
 
-for ($i=0, $n=count( $this->items ); $i < $n; $i++) {
-    $item = $this->items[$i];
+for ($i=0, $n=count( $this->items ); $i < $n; $i++)
+{
+	$item = $this->items[$i];
 
-    if ($item->uri_type == 'file') {
-        if ($secure) {
-            $url = Route::_("index.php?option=com_attachments&amp;task=attachment.download&amp;id=" . (int)$item->id);
-        } else {
-            $url = $uri->root(true) . '/' . $item->url;
-        }
-    } else {
-        $url = $item->url;
-    }
-    $checked = HTMLHelper::_('grid.id', $i, $item->id);
-    $published = HTMLHelper::_('jgrid.published', $item->state, $i, 'attachments.');
-    $access = $this->level_name[$item->access];
+	if ( $item->uri_type == 'file' ) {
+		if ( $secure ) {
+			$url = Route::_("index.php?option=com_attachments&amp;task=attachment.download&amp;id=" . (int)$item->id);
+			}
+		else {
+			$url = $uri->root(true) . '/' . $item->url;
+			}
+		}
+	else {
+		$url = $item->url;
+		}
+	$checked = HTMLHelper::_('grid.id', $i, $item->id );
+	$published = HTMLHelper::_('jgrid.published', $item->state, $i, 'attachments.' );
+	$access = $this->level_name[$item->access];
 
     $size_kb = (int)(10 * $item->file_size / 1024) / 10.0;
     $link = OutputFilter::ampReplace('index.php?option=com_attachments&amp;task=attachment.edit&amp;cid[]=' . (int)$item->id);

--- a/attachments_component/admin/tmpl/attachments/default_body.php
+++ b/attachments_component/admin/tmpl/attachments/default_body.php
@@ -11,6 +11,7 @@
  * @author Jonathan M. Cameron
  */
 
+use JMCameron\Component\Attachments\Site\Helper\AttachmentsFileTypes;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
@@ -30,6 +31,8 @@ $params = $this->params;
 $secure = $params->get('secure',false);
 $superimpose_link_icons = $params->get('superimpose_url_link_icons', true);
 $icon_dir = $uri->root(true) . '/components/com_attachments/media/icons/';
+$use_fontawesome_icons = $params->get('use_fontawesome_icons', false);
+$use_fontawesome_icons_style = $params->get('use_fontawesome_icons_style', 'fas');
 
 // Loop through all the attachments
 $k = 0;
@@ -38,32 +41,34 @@ $last_parent_type = null;
 $last_parent_entity = null;
 
 
-for ($i=0, $n=count( $this->items ); $i < $n; $i++)
-{
-	$item = $this->items[$i];
+for ($i=0, $n=count( $this->items ); $i < $n; $i++) {
+    $item = $this->items[$i];
 
-	if ( $item->uri_type == 'file' ) {
-		if ( $secure ) {
-			$url = Route::_("index.php?option=com_attachments&amp;task=attachment.download&amp;id=" . (int)$item->id);
-			}
-		else {
-			$url = $uri->root(true) . '/' . $item->url;
-			}
-		}
-	else {
-		$url = $item->url;
-		}
-	$checked = HTMLHelper::_('grid.id', $i, $item->id );
-	$published = HTMLHelper::_('jgrid.published', $item->state, $i, 'attachments.' );
-	$access = $this->level_name[$item->access];
+    if ($item->uri_type == 'file') {
+        if ($secure) {
+            $url = Route::_("index.php?option=com_attachments&amp;task=attachment.download&amp;id=" . (int)$item->id);
+        } else {
+            $url = $uri->root(true) . '/' . $item->url;
+        }
+    } else {
+        $url = $item->url;
+    }
+    $checked = HTMLHelper::_('grid.id', $i, $item->id);
+    $published = HTMLHelper::_('jgrid.published', $item->state, $i, 'attachments.');
+    $access = $this->level_name[$item->access];
 
-	$size_kb = (int)(10 * $item->file_size / 1024) / 10.0;
-	$link = OutputFilter::ampReplace( 'index.php?option=com_attachments&amp;task=attachment.edit&amp;cid[]='. (int)$item->id );
-	$view_parent_title = Text::_('ATTACH_VIEW_ARTICLE_TITLE');
-	if ( StringHelper::strlen($item->icon_filename) > 0 )
-		$icon = $item->icon_filename;
-	else
-		$icon = 'generic.gif';
+    $size_kb = (int)(10 * $item->file_size / 1024) / 10.0;
+    $link = OutputFilter::ampReplace('index.php?option=com_attachments&amp;task=attachment.edit&amp;cid[]=' . (int)$item->id);
+    $view_parent_title = Text::_('ATTACH_VIEW_ARTICLE_TITLE');
+    if ($use_fontawesome_icons) {
+        $icon = AttachmentsFileTypes::fa_icon_filename('', $item->file_type);
+        }
+    else {
+        if (StringHelper::strlen($item->icon_filename) > 0)
+            $icon = $item->icon_filename;
+        else
+            $icon = 'generic.gif';
+    }
 	$add_attachment_title = Text::_('ATTACH_ADD_ATTACHMENT_TITLE');
 	$edit_attachment_title = Text::_('ATTACH_EDIT_THIS_ATTACHMENT_TITLE');
 	$access_attachment_title = Text::_('ATTACH_ACCESS_THIS_ATTACHMENT_TITLE');
@@ -100,7 +105,12 @@ for ($i=0, $n=count( $this->items ); $i < $n; $i++)
 				"href=\"".$item->parent_url."\" target=\"_blank\">" . $item->parent_title . "</a>";
 			$artLine .= OutputFilter::ampReplace('&nbsp;&nbsp;&nbsp;&nbsp;');
 			$artLine .= "<a class=\"addAttach\" href=\"$addAttachLink\" title=\"$add_attachment_title\">";
-			$artLine .= HTMLHelper::image('com_attachments/add_attachment.gif', $add_attachment_txt, null, true);
+            if ($use_fontawesome_icons) {
+                $artLine .= '<i class="' . $use_fontawesome_icons_style . ' fa-paperclip"></i>';
+                }
+            else {
+                $artLine .= HTMLHelper::image('com_attachments/add_attachment.gif', $add_attachment_txt, null, true);
+                }
 			$artLine .= "</a>&nbsp;<a class=\"addAttach\" href=\"$addAttachLink\" title=\"$add_attachment_title\">" .
 				"$add_attachment_txt</a>";
 			$artLine .= "</td></tr>";
@@ -122,13 +132,29 @@ for ($i=0, $n=count( $this->items ); $i < $n; $i++)
 	  <?php if ( !$this->editor ) : ?>
 		 <a href="<?php echo $link; ?>" title="<?php echo $edit_attachment_title; ?>" >
 	  <?php endif; ?>
-		  <?php echo HTMLHelper::image('com_attachments/file_icons/'.$icon, $download_verb, null, true);
+		  <?php
+            if ($use_fontawesome_icons) {
+                echo '<i class="' . $use_fontawesome_icons_style . ' ' . $icon . '"></i>';
+                }
+            else {
+                echo HTMLHelper::image('com_attachments/file_icons/' . $icon, $download_verb, null, true);
+                }
 		if ( ($item->uri_type == 'url') && $superimpose_link_icons ) {
 			if ( $item->url_valid ) {
-				echo HTMLHelper::image('com_attachments/file_icons/link_arrow.png', '', 'class="link_overlay"', true);
+                if ($use_fontawesome_icons) {
+                    echo '&nbsp;<i class="' . $use_fontawesome_icons_style . ' fa-eye-slash"></i>';
+                }
+                else {
+                    echo HTMLHelper::image('com_attachments/file_icons/link_arrow.png', '', 'class="link_overlay"', true);
+                    }
 				}
 			else {
-				echo HTMLHelper::image('com_attachments/file_icons/link_broken.png', '', 'class="link_overlay"', true);
+                if ($use_fontawesome_icons) {
+                    echo '&nbsp;<i class="' . $use_fontawesome_icons_style . ' fa-eye-slash redicon"></i>';
+                }
+                else {
+                    echo HTMLHelper::image('com_attachments/file_icons/link_broken.png', '', 'class="link_overlay"', true);
+                    }
 				}
 			}
 		 ?>
@@ -148,11 +174,16 @@ for ($i=0, $n=count( $this->items ); $i < $n; $i++)
 					echo $item->url;
 					}
 				}
-			   ?></a>&nbsp;&nbsp;<a class="downloadAttach" href="<?php echo $url; ?>" target="_blank"
+			   ?></a>&nbsp;&nbsp;
+          <?php if(!$use_fontawesome_icons): ?>
+          <a class="downloadAttach" href="<?php echo $url; ?>" target="_blank"
 		 title="<?php echo $access_attachment_title; ?>"><?php echo $download_verb;
 		  ?></a><a class="downloadAttach" href="<?php echo $url; ?>"  target="_blank"
 		 title="<?php echo $access_attachment_title; ?>"
 		  ><?php echo HTMLHelper::image('com_attachments/download.gif', $download_verb, null, true); ?></a>
+        <?php else: echo '<a class="downloadAttach" href="'.$url.'"  target="_blank"
+		 title="' . $access_attachment_title . '"
+		  ><i class="' . $use_fontawesome_icons_style . ' fa-download"></i></a>'; endif; ?>
 	  </td>
 	  <td class="at_description"><?php echo htmlspecialchars(stripslashes($item->description)); ?></td>
 	  <td class="at_access" align="center"><?php echo $access; ?></td>

--- a/attachments_component/media/css/attachments_admin.css
+++ b/attachments_component/media/css/attachments_admin.css
@@ -547,3 +547,7 @@ body.com_attachments h1.page-title {
 	background-image: url(../images/attachments_logo32.png);
 	background-repeat: no-repeat;
 }
+
+form#adminForm .redicon {
+	color: red;
+}

--- a/attachments_component/media/css/attachments_list.css
+++ b/attachments_component/media/css/attachments_list.css
@@ -262,3 +262,8 @@ form.attachmentsBackend + div.attachmentsList table {
 .modal-body.jviewport-height80 { 
 	height: 80vh;
 }
+
+#main div.attachmentsContainer,
+div.attachmentsContainer .redicon {
+    color: red;
+}

--- a/attachments_component/site/src/Helper/AttachmentsFileTypes.php
+++ b/attachments_component/site/src/Helper/AttachmentsFileTypes.php
@@ -446,7 +446,7 @@ class AttachmentsFileTypes {
             $pathInfo = pathinfo($filename);
 
             // Try the extension first
-            $extension = strtolower($pathInfo['extension']);
+            $extension = StringHelper::strtolower($pathInfo['extension']);
 
             if (array_key_exists($extension, self::ATTACHMENTS_ICON_FROM_FILE_EXTENSION_FA))
             {

--- a/attachments_component/site/src/Helper/AttachmentsFileTypes.php
+++ b/attachments_component/site/src/Helper/AttachmentsFileTypes.php
@@ -87,7 +87,80 @@ class AttachmentsFileTypes {
 			   '_link' => 'link.gif',
 			   );
 
-	/** Array of lookups for icon filename from mime type */
+    /**
+     * Array of lookups for FontAwesome icon given a filename extension
+     *
+     * @access  public
+     *
+     * @var     array
+     *
+     * @since   1.0.0
+     */
+    public const ATTACHMENTS_ICON_FROM_FILE_EXTENSION_FA = [
+        'aif' => 'fa-file-audio',
+        'aiff' => 'fa-file-audio',
+        'avi' => 'fa-file-video',
+        'avif' => 'fa-file-image',
+        'bmp' => 'fa-file-image',
+        'bz2' => 'fa-file-archive',
+        'c' => 'fa-file-code',
+        'c++' => 'fa-file-code',
+        'cab' => 'fa-file-archive',
+        'cc' => 'fa-file-code',
+        'cpp' => 'fa-file-code',
+        'css' => 'fa-file-code',
+        'csv' => 'fa-file-lines',
+        'doc' => 'fa-file-word',
+        'docx' => 'fa-file-word',
+        'eps' => 'fa-file-image',
+        'gif' => 'fa-file-image',
+        'gz' => 'fa-file-archive',
+        'h' => 'fa-file-code',
+        'iv' => 'fa-file-image',
+        'jpg' => 'fa-file-image',
+        'js' => 'fa-file-code',
+        'midi' => 'fa-file-audio',
+        'mov' => 'fa-file-video',
+        'mp3' => 'fa-file-audio',
+        'mpeg' => 'fa-file-video',
+        'mpg' => 'fa-file-video',
+        'odg' => 'fa-file-image',
+        'odp' => 'fa-file-powerpoint',
+        'ods' => 'fa-file-excel',
+        'odt' => 'fa-file-word',
+        'pdf' => 'fa-file-pdf',
+        'php' => 'fa-file-code',
+        'png' => 'fa-file-image',
+        'pps' => 'fa-file-powerpoint',
+        'ppt' => 'fa-file-powerpoint',
+        'pptx' => 'fa-file-powerpoint',
+        'ps' => 'fa-file-image',
+        'ra' => 'fa-file-audio',
+        'ram' => 'fa-file-audio',
+        'rar' => 'fa-file-archive',
+        'rtf' => 'fa-file-lines',
+        'sql' => 'fa-file-code',
+        'swf' => 'fa-file-video',
+        'tar' => 'fa-file-archive',
+        'txt' => 'fa-file-lines',
+        'vcf' => 'fa-address-card',
+        'vrml' => 'fa-file-image',
+        'wav' => 'fa-file-audio',
+        'webp' => 'fa-file-image',
+        'wma' => 'fa-file-audio',
+        'wmv' => 'fa-file-video',
+        'wrl' => 'fa-file-image',
+        'xls' => 'fa-file-excel',
+        'xlsx' => 'fa-file-excel',
+        'xml' => 'fa-file-code',
+        'zip' => 'fa-file-archive',
+
+        // Artificial
+        '_generic' => 'fa-file',
+        '_link' => 'fa-link',
+    ];
+
+    /** Array of lookups for icon filename from mime type */
 	static $attachments_icon_from_mime_type =
 		Array( 'application/bzip2' => 'archive.gif',
 			   'application/excel' => 'excel.gif',
@@ -117,7 +190,8 @@ class AttachmentsFileTypes {
 			   'application/x-rar-compressed' => 'archive.gif',
 			   'application/x-tar' => 'archive.gif', 
 			   'application/x-vrml' => '3d.gif', 
-			   'application/x-zip' => 'zip.gif', 
+			   'application/x-zip' => 'zip.gif',
+               'application/x-zip-compressed' => 'zip.gif',
 			   'application/xml' => 'xml.gif',
 			   'audio/mpeg' => 'music.gif',
 			   'audio/x-aiff' => 'music.gif',
@@ -144,7 +218,76 @@ class AttachmentsFileTypes {
 			   'link/unknown' => 'link.gif'
 			   );
 
-	/** Array of lookups for mime type from filename extension */
+    /**
+     * Array of lookups for FontAwesome icon from mime type
+     *
+     * @access  public
+     *
+     * @var     array
+     *
+     * @since   1.0.0
+     */
+    public const ATTACHMENTS_ICON_FROM_MIME_TYPE_FA = [
+        'application/bzip2' => 'fa-file-archive',
+        'application/excel' => 'fa-file-excel',
+        'application/msword' => 'fa-file-word',
+        'application/pdf' => 'fa-file-pdf',
+        'application/postscript' => 'fa-file-image',
+        'application/powerpoint' => 'fa-file-powerpoint',
+        'application/rtf' => 'fa-file',
+        'application/vnd.ms-cab-compressed' => 'fa-file-archive',
+        'application/vnd.ms-excel' => 'fa-file-excel',
+        'application/vnd.ms-powerpoint' => 'fa-file-powerpoint',
+        'application/vnd.ms-pps' => 'fa-file-powerpoint',
+        'application/vnd.ms-word' => 'fa-file-word',
+        'application/vnd.oasis.opendocument.graphics' => 'fa-file-image',
+        'application/vnd.oasis.opendocument.presentation' => 'fa-file-powerpoint',
+        'application/vnd.oasis.opendocument.spreadsheet' => 'fa-file-excel',
+        'application/vnd.oasis.opendocument.text' => 'fa-file-word',
+        'application/vnd.openxmlformats' => 'fa-file-code',
+        'application/vnd.openxmlformats-officedocument.presentationml.presentation' => 'fa-file-powerpoint',
+        'application/vnd.openxmlformats-officedocument.presentationml.slideshow' => 'fa-file-powerpoint',
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' => 'fa-file-excel',
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document' => 'fa-file-word',
+        'application/x-bz2' => 'fa-file-archive',
+        'application/x-gzip' => 'fa-file-archive',
+        'application/x-javascript' => 'fa-file-code',
+        'application/x-midi' => 'fa-file-audio',
+        'application/x-shockwave-flash' => 'fa-file-video',
+        'application/x-rar-compressed' => 'fa-file-archive',
+        'application/x-tar' => 'fa-file-archive',
+        'application/x-vrml' => 'fa-file-image',
+        'application/x-zip' => 'fa-file-archive',
+        'application/x-zip-compressed' => 'fa-file-archive',
+        'application/xml' => 'fa-file-code',
+        'audio/mpeg' => 'fa-file-audio',
+        'audio/x-aiff' => 'fa-file-audio',
+        'audio/x-ms-wma' => 'fa-file-audio',
+        'audio/x-pn-realaudio' => 'fa-file-audio',
+        'audio/x-wav' => 'fa-file-audio',
+        'image/avif' => 'fa-file-image',
+        'image/bmp' => 'fa-file-image',
+        'image/gif' => 'fa-file-image',
+        'image/jpeg' => 'fa-file-image',
+        'image/png' => 'fa-file-image',
+        'image/webp' => 'fa-file-image',
+        'model/vrml' => 'fa-file-image  ',
+        'text/css' => 'fa-file-code',
+        'text/html' => 'fa-file',
+        'text/plain' => 'fa-file-lines',
+        'text/rtf' => 'fa-file-lines',
+        'text/x-vcard' => 'fa-address-card',
+        'video/mpeg' => 'fa-file-video',
+        'video/quicktime' => 'fa-file-video',
+        'video/x-ms-wmv' => 'fa-file-video',
+        'video/x-msvideo' => 'fa-file-video',
+
+        // Artificial
+        'link/generic' => 'fa-file',
+        'link/unknown' => 'fa-link'
+    ];
+
+    /** Array of lookups for mime type from filename extension */
 	static $attachments_mime_type_from_extension =
 		Array( 'aif' => 'audio/x-aiff',
 			   'aiff' => 'audio/x-aiff',
@@ -266,8 +409,63 @@ class AttachmentsFileTypes {
 		return '';
 	}
 
-	
-	/**
+    /**
+     * Get the FontAwesome icon name for a specific filename (or mime type)
+     *
+     * @access  public
+     *
+     * @param   string  $filename  the filename to check
+     * @param   string  $mimeType  the MIME type to check (if the filename fails)
+     *
+     * @return  string  the FontAwesome icon name (or '' if none is found)
+     *
+     * @since   4.1.2
+     */
+    public static function fa_icon_filename(string $filename, string $mimeType): string
+    {
+        // Recognize some special cases first
+        if (($mimeType == 'link/unknown') || ($mimeType == 'unknown'))
+        {
+            return 'fa-link';
+        }
+
+        if ($mimeType == 'link/broken')
+        {
+            return 'fa-link-slashed';
+        }
+
+        if ($filename)
+        {
+            // Make sure it is a real filename
+            if (strpos($filename, '.') === false)
+            {
+                // Do not know any better, assume it is text
+                return 'fa-file-lines';
+            }
+
+            $pathInfo = pathinfo($filename);
+
+            // Try the extension first
+            $extension = strtolower($pathInfo['extension']);
+
+            if (array_key_exists($extension, self::ATTACHMENTS_ICON_FROM_FILE_EXTENSION_FA))
+            {
+                return self::ATTACHMENTS_ICON_FROM_FILE_EXTENSION_FA[$extension];
+            }
+        }
+        else
+        {
+            // Try the mime type
+            if (array_key_exists($mimeType, self::ATTACHMENTS_ICON_FROM_MIME_TYPE_FA))
+            {
+                return self::ATTACHMENTS_ICON_FROM_MIME_TYPE_FA[$mimeType];
+            }
+        }
+
+        return '';
+    }
+
+    /**
 	 * Get an array of unique icon filenames
 	 *
 	 * @return an array of unique icon filenames

--- a/attachments_component/site/src/Helper/AttachmentsHelper.php
+++ b/attachments_component/site/src/Helper/AttachmentsHelper.php
@@ -1946,7 +1946,15 @@ class AttachmentsHelper
 
 		$links .= "<a class=\"$a_class\" type=\"button\" data-bs-toggle='modal' data-bs-target='#modal-$randomId'";
 		$links .= "title=\"$tooltip\">";
-		$links .= HTMLHelper::image('com_attachments/add_attachment.gif', $add_attachment_txt, null, true);
+
+        // Get the component parameters
+        $params = ComponentHelper::getParams('com_attachments');
+        if ($params->get('use_fontawesome_icons')) {
+            $links .= '<i class="' . $params->get('use_fontawesome_icons_style') . ' fa-paperclip"></i>';
+            }
+        else {
+            $links .= HTMLHelper::image('com_attachments/add_attachment.gif', $add_attachment_txt, null, true);
+        }
 		$links .= " $add_attachment_txt</a>";
 
 		return "\n<div class=\"addattach\">$links</div>\n";

--- a/attachments_component/site/src/View/Attachments/HtmlView.php
+++ b/attachments_component/site/src/View/Attachments/HtmlView.php
@@ -180,6 +180,8 @@ class HtmlView extends BaseHtmlView
 		$this->show_modified_date =	$params->get('show_modified_date', false);
 		$this->file_link_open_mode = $params->get('file_link_open_mode', 'in_same_window');
 		$this->show_raw_download = $params->get('show_raw_download', false);
+        $this->use_fontawesome_icons = $params->get('use_fontawesome_icons', false);
+        $this->use_fontawesome_icons_style = $params->get('use_fontawesome_icons_style', 'fas');
 
 		// Set up the file/url titleshow_mod_date
 		if ( $this->show_column_titles ) {

--- a/attachments_component/site/tmpl/attachments/default.php
+++ b/attachments_component/site/tmpl/attachments/default.php
@@ -397,7 +397,8 @@ for ($i=0, $n=count($attachments); $i < $n; $i++) {
         $html .=  '<td class="at_icon">';
         $tooltip = Text::sprintf('ATTACH_DOWNLOAD_THIS_FILE_S', $actual_filename);
         if ($this->use_fontawesome_icons) {
-            $html .= '<i class="' . $faIconsStyle . ' fa-download"></i>';
+            $html .= "<a class=\"" . $a_class . "\" href=\"$url\"$target title=\"$tooltip\">" . 
+				'<i class="' . $faIconsStyle . ' fa-download"></i></a></td>';
             }
         else {
             $html .= "<a class=\"" . $a_class . "\" href=\"$url\"$target title=\"$tooltip\">" .

--- a/attachments_component/site/tmpl/attachments/default.php
+++ b/attachments_component/site/tmpl/attachments/default.php
@@ -13,6 +13,7 @@
 
 use JMCameron\Component\Attachments\Site\Helper\AttachmentsDefines;
 use JMCameron\Component\Attachments\Site\Helper\AttachmentsJavascript;
+use JMCameron\Component\Attachments\Site\Helper\AttachmentsFileTypes;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
@@ -109,7 +110,11 @@ if ( $this->file_link_open_mode == 'in_a_popup' ) {
 	AttachmentsJavascript::setupModalJavascript();
 }
 
-// Construct the lines for the attachments
+if ($this->use_fontawesome_icons) {
+    $faIconsStyle = $this->use_fontawesome_icons_style;
+}
+
+    // Construct the lines for the attachments
 $row_num = 0;
 for ($i=0, $n=count($attachments); $i < $n; $i++) {
 	$attachment = $attachments[$i];
@@ -129,10 +134,16 @@ for ($i=0, $n=count($attachments); $i < $n; $i++) {
 	$html .= '<tr class="'.$row_class.'">';
 		
 	// Construct some display items
-	if ( StringHelper::strlen($attachment->icon_filename) > 0 )
-		$icon = $attachment->icon_filename;
-	else
-		$icon = 'generic.gif';
+    if ($this->use_fontawesome_icons)
+    {
+        $icon = AttachmentsFileTypes::fa_icon_filename('', $attachment->file_type);
+    }
+    else {
+        if (StringHelper::strlen($attachment->icon_filename) > 0)
+            $icon = $attachment->icon_filename;
+        else
+            $icon = 'generic.gif';
+    }
 
 	if ( $this->show_file_size) {
 		$file_size = (int)( $attachment->file_size / 1024.0 );
@@ -221,52 +232,77 @@ for ($i=0, $n=count($attachments); $i < $n; $i++) {
 		$show_in_modal = (!$app->client->mobile) && ($this->file_link_open_mode == 'in_a_popup') && ($attachment->file_type === "application/pdf" || str_starts_with($attachment->file_type, "image/"));
 		
 		if ( $show_in_modal ) {
-			$a_class = 'modal-button';
-			AttachmentsJavascript::setupModalJavascript();
+            $a_class = 'modal-button';
+            AttachmentsJavascript::setupModalJavascript();
 
-			$randomId = base64_encode('show'.$actual_filename);
-			// Remove +,/,= from the $randomId
-			$randomId = strtr($randomId, "+/=", "AAA");
-			$modalParams['title']  = $this->escape($tooltip);
-			$modalParams['url']    = $url;
-			$modalParams['height'] = '80%';
-			$modalParams['width']  = '80%';
-			$modalParams['bodyHeight'] = '80';
-			$modalParams['modalWidth'] = '80';
-			$url .= "&popup=1";
-			$html .= LayoutHelper::render(
-				'libraries.html.bootstrap.modal.main', 
-				[
-					'selector' => 'modal-' . $randomId, 
-					'body' => "<iframe src=\"$url\" scrolling=\"auto\" loading=\"lazy\" width='95%' height='95%'></iframe>",
-					'params' => $modalParams
-				]
-			);
+            $randomId = base64_encode('show' . $actual_filename);
+            // Remove +,/,= from the $randomId
+            $randomId = strtr($randomId, "+/=", "AAA");
+            $modalParams['title'] = $this->escape($tooltip);
+            $modalParams['url'] = $url;
+            $modalParams['height'] = '80%';
+            $modalParams['width'] = '80%';
+            $modalParams['bodyHeight'] = '80';
+            $modalParams['modalWidth'] = '80';
+            $url .= "&popup=1";
+            $html .= LayoutHelper::render(
+                'libraries.html.bootstrap.modal.main',
+                [
+                    'selector' => 'modal-' . $randomId,
+                    'body' => "<iframe src=\"$url\" scrolling=\"auto\" loading=\"lazy\" width='95%' height='95%'></iframe>",
+                    'params' => $modalParams
+                ]
+            );
 
-			$show_link = "<a class=\"$a_class\" type=\"button\" data-bs-toggle='modal' data-bs-target='#modal-$randomId'";
-			$show_link .= "title=\"$tooltip\">";
-			$show_link .= HTMLHelper::image('com_attachments/file_icons/'.$icon, $tooltip, null, true);
+            $show_link = "<a class=\"$a_class\" type=\"button\" data-bs-toggle='modal' data-bs-target='#modal-$randomId'";
+            $show_link .= "title=\"$tooltip\">";
+            if ($this->use_fontawesome_icons) {
+                $show_link .= '<i class="' . $faIconsStyle . ' ' . $icon . '"></i>';
+                }
+            else {
+                $show_link .= HTMLHelper::image('com_attachments/file_icons/'.$icon, $tooltip, null, true);
+            }
 			$show_link .= "&nbsp;" . $filename . "</a>";
 			}
 		else {
 			$a_class = 'at_icon';
 			$show_link = "<a class=\"". $a_class . "\" href=\"$url\"$target title=\"$tooltip\">";
-			$show_link .= HTMLHelper::image('com_attachments/file_icons/'.$icon, null, null, true);
+            if ($this->use_fontawesome_icons) {
+                $show_link .= '<i class="' . $faIconsStyle . ' ' . $icon . '"></i>';
+                }
+            else {
+                $show_link .= HTMLHelper::image('com_attachments/file_icons/' . $icon, null, null, true);
+            }
 			$show_link .= "&nbsp;" . $filename . "</a>";
 		}
 		$html .= $show_link;
 		if ( ($attachment->uri_type == 'url') && $this->superimpose_link_icons ) {
 			if ( $attachment->url_valid ) {
-				$html .= HTMLHelper::image('com_attachments/file_icons/link_arrow.png', '', 'class="link_overlay"', true);
+                if ($this->use_fontawesome_icons) {
+                    $html .= '<i class="' . $faIconsStyle . ' fa-eye-slash"></i>';
+                    }
+                else {
+                    $html .= HTMLHelper::image('com_attachments/file_icons/link_arrow.png', '', 'class="link_overlay"', true);
+                    }
 				}
 			else {
-				$html .= HTMLHelper::image('com_attachments/file_icons/link_broken.png', '', 'class="link_overlay"', true);
+                if ($this->use_fontawesome_icons) {
+                    $html .= '<i class="' . $faIconsStyle . ' fa-eye-slash redicon"></i>';
+                    }
+                else {
+                    $html .= HTMLHelper::image('com_attachments/file_icons/link_broken.png', '', 'class="link_overlay"', true);
+                }
 				}
 			}
 		}
 	else {
 		$tooltip = Text::sprintf('ATTACH_DOWNLOAD_THIS_FILE_S', $actual_filename);
-		$html .= HTMLHelper::image('com_attachments/file_icons/'.$icon, $tooltip, null, true);
+        if ($this->use_fontawesome_icons) {
+            $html .= '<i class="' . $faIconsStyle . ' ' . $icon . '" title="' . $tooltip . '"></i>';
+            }
+        else {
+            $html .= HTMLHelper::image('com_attachments/file_icons/' . $icon, $tooltip, null, true);
+        }
 		$html .= '&nbsp;' . $filename;
 		}
 	$html .= "</td>";
@@ -360,8 +396,13 @@ for ($i=0, $n=count($attachments); $i < $n; $i++) {
         $url = Route::_($base_url . "index.php?option=com_attachments&task=download&id=" . (int)$attachment->id . "&raw=1");
         $html .=  '<td class="at_icon">';
         $tooltip = Text::sprintf('ATTACH_DOWNLOAD_THIS_FILE_S', $actual_filename);
-        $html .= "<a class=\"". $a_class . "\" href=\"$url\"$target title=\"$tooltip\">" .
+        if ($this->use_fontawesome_icons) {
+            $html .= '<i class="' . $faIconsStyle . ' fa-download"></i>';
+            }
+        else {
+            $html .= "<a class=\"" . $a_class . "\" href=\"$url\"$target title=\"$tooltip\">" .
                 HTMLHelper::image("com_attachments/download.gif", "", null, true) . '</a></td>';
+        }
     }
 	// Show number of downloads (maybe)
 	if ( $this->secure && $this->show_downloads ) {
@@ -419,7 +460,12 @@ for ($i=0, $n=count($attachments); $i < $n; $i++) {
 
 		$update_link = "<a class=\"$a_class\" type=\"button\" data-bs-toggle='modal' data-bs-target='#modal-$randomId'";
 		$update_link .= "title=\"$tooltip\">";
-		$update_link .= HTMLHelper::image('com_attachments/pencil.gif', $tooltip, null, true);
+        if ($this->use_fontawesome_icons) {
+            $update_link .= '<i class="' . $faIconsStyle . ' fa-edit"></i>';
+        }
+        else {
+            $update_link .= HTMLHelper::image('com_attachments/pencil.gif', $tooltip, null, true);
+            }
 		$update_link .= "</a>";
 		}
 
@@ -450,7 +496,12 @@ for ($i=0, $n=count($attachments); $i < $n; $i++) {
 
 		$delete_link = "<a class=\"$a_class\" type=\"button\" data-bs-toggle='modal' data-bs-target='#modal-$randomId'";
 		$delete_link .= "title=\"$tooltip\">";
-		$delete_link .= HTMLHelper::image('com_attachments/delete.gif', $tooltip, null, true);
+        if ($this->use_fontawesome_icons) {
+            $delete_link .= '<i class="' . $faIconsStyle . ' fa-trash"></i>';
+            }
+        else {
+            $delete_link .= HTMLHelper::image('com_attachments/delete.gif', $tooltip, null, true);
+        }
 		$delete_link .= "</a>";
 		}
 

--- a/attachments_component/site/tmpl/attachments/default.php
+++ b/attachments_component/site/tmpl/attachments/default.php
@@ -114,7 +114,7 @@ if ($this->use_fontawesome_icons) {
     $faIconsStyle = $this->use_fontawesome_icons_style;
 }
 
-    // Construct the lines for the attachments
+// Construct the lines for the attachments
 $row_num = 0;
 for ($i=0, $n=count($attachments); $i < $n; $i++) {
 	$attachment = $attachments[$i];
@@ -232,27 +232,27 @@ for ($i=0, $n=count($attachments); $i < $n; $i++) {
 		$show_in_modal = (!$app->client->mobile) && ($this->file_link_open_mode == 'in_a_popup') && ($attachment->file_type === "application/pdf" || str_starts_with($attachment->file_type, "image/"));
 		
 		if ( $show_in_modal ) {
-            $a_class = 'modal-button';
-            AttachmentsJavascript::setupModalJavascript();
+			$a_class = 'modal-button';
+			AttachmentsJavascript::setupModalJavascript();
 
-            $randomId = base64_encode('show' . $actual_filename);
-            // Remove +,/,= from the $randomId
-            $randomId = strtr($randomId, "+/=", "AAA");
-            $modalParams['title'] = $this->escape($tooltip);
-            $modalParams['url'] = $url;
-            $modalParams['height'] = '80%';
-            $modalParams['width'] = '80%';
-            $modalParams['bodyHeight'] = '80';
-            $modalParams['modalWidth'] = '80';
-            $url .= "&popup=1";
-            $html .= LayoutHelper::render(
-                'libraries.html.bootstrap.modal.main',
-                [
-                    'selector' => 'modal-' . $randomId,
-                    'body' => "<iframe src=\"$url\" scrolling=\"auto\" loading=\"lazy\" width='95%' height='95%'></iframe>",
-                    'params' => $modalParams
-                ]
-            );
+			$randomId = base64_encode('show'.$actual_filename);
+			// Remove +,/,= from the $randomId
+			$randomId = strtr($randomId, "+/=", "AAA");
+			$modalParams['title']  = $this->escape($tooltip);
+			$modalParams['url']    = $url;
+			$modalParams['height'] = '80%';
+			$modalParams['width']  = '80%';
+			$modalParams['bodyHeight'] = '80';
+			$modalParams['modalWidth'] = '80';
+			$url .= "&popup=1";
+			$html .= LayoutHelper::render(
+				'libraries.html.bootstrap.modal.main', 
+				[
+					'selector' => 'modal-' . $randomId, 
+					'body' => "<iframe src=\"$url\" scrolling=\"auto\" loading=\"lazy\" width='95%' height='95%'></iframe>",
+					'params' => $modalParams
+				]
+			);
 
             $show_link = "<a class=\"$a_class\" type=\"button\" data-bs-toggle='modal' data-bs-target='#modal-$randomId'";
             $show_link .= "title=\"$tooltip\">";


### PR DESCRIPTION
Backend component view

![obraz](https://github.com/user-attachments/assets/a784a6c5-cdc9-496a-abf1-3e579c6794fb)

Frontend componet view (attachments list)

![obraz](https://github.com/user-attachments/assets/1969f4c9-ce1c-4633-a9f8-433249da2e0d)

(list css modified to make a screenshot)

ATM icons on help page stays as they are, only front/backend attachments lists are touched.

There are two styles of FA available in vanilla Joomla!, regular and solid, this modification can only use FontAwesome PRO.

