### PR TITLE
Adiciona tradução pt-BR para todos os plugins e componentes

### DIFF
--- a/language/pt-BR/pt-BR.pkg_attachments.sys.ini
+++ b/language/pt-BR/pt-BR.pkg_attachments.sys.ini
@@ -1,0 +1,8 @@
+; Portuguese (Brazil) translation for Attachments package
+; Tradução para Português do Brasil do pacote Attachments
+
+PKG_ATTACHMENTS="Gestor de Anexos"
+PKG_ATTACHMENTS_DESC="Permite adicionar anexos aos artigos do Joomla! com o Gestor de Anexos."
+PKG_ATTACHMENTS_INSTALL="Instalação do Gestor de Anexos concluída com sucesso."
+PKG_ATTACHMENTS_UNINSTALL="Desinstalação do Gestor de Anexos concluída com sucesso."
+PKG_ATTACHMENTS_UPDATE="Atualização do Gestor de Anexos concluída com sucesso."

--- a/packages/add_attachment_btn_plugin/add_attachment.xml
+++ b/packages/add_attachment_btn_plugin/add_attachment.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension type="plugin" group="editors-xtd" version="4.0" method="upgrade">
+    <name>plg_editors-xtd_add_attachment_btn</name>
+    <version>4.1.6</version>
+    <creationDate>August  1, 2025</creationDate>
+    <author>Jonathan M. Cameron</author>
+    <copyright>(C) 2007-2025 Jonathan M. Cameron. All rights reserved.</copyright>
+    <license>https://www.gnu.org/licenses/gpl-3.0.html GNU/GPL</license>
+    <authorEmail>jmcameron@jmcameron.net</authorEmail>
+    <authorUrl>https://github.com/jmcameron/attachments</authorUrl>
+    <description>ATTACH_ADD_ATTACHMENT_BUTTON_PLUGIN_DESCRIPTION</description>
+    <namespace path="src">JMCameron\Plugin\EditorsXtd\AddAttachment</namespace>
+    <files>
+        <folder plugin="add_attachment">services</folder>
+	    <folder>src</folder>
+    </files>
+	<languages>
+		<language tag="en-GB">language/en-GB/en-GB.plg_editors-xtd_add_attachment.ini</language>
+		<language tag="en-GB">language/en-GB/en-GB.plg_editors-xtd_add_attachment.sys.ini</language>
+		<language tag="el-GR">language/el-GR/el-GR.plg_editors-xtd_add_attachment.ini</language>
+		<language tag="el-GR">language/el-GR/el-GR.plg_editors-xtd_add_attachment.sys.ini</language>
+		<language tag="fr-FR">language/fr-FR/fr-FR.plg_editors-xtd_add_attachment.ini</language>
+		<language tag="fr-FR">language/fr-FR/fr-FR.plg_editors-xtd_add_attachment.sys.ini</language>
+        <language tag="pt-BR">language/pt-BR/pt-BR.plg_editors-xtd_add_attachment.ini</language>
+        <language tag="pt-BR">language/pt-BR/pt-BR.plg_editors-xtd_add_attachment.sys.ini</language>
+	</languages>
+</extension>

--- a/packages/add_attachment_btn_plugin/language/pt-BR/pt-BR.plg_add_attachment_btn_plugin.sys.ini
+++ b/packages/add_attachment_btn_plugin/language/pt-BR/pt-BR.plg_add_attachment_btn_plugin.sys.ini
@@ -1,0 +1,6 @@
+; Tradução para Português do Brasil do plugin Botão Adicionar Anexo
+PLG_ADD_ATTACHMENT_BTN_PLUGIN="Botão Adicionar Anexo"
+PLG_ADD_ATTACHMENT_BTN_PLUGIN_DESC="Adiciona um botão para anexar arquivos aos artigos usando o Gestor de Anexos."
+PLG_ADD_ATTACHMENT_BTN_PLUGIN_INSTALL="Instalação do plugin Botão Adicionar Anexo concluída com sucesso."
+PLG_ADD_ATTACHMENT_BTN_PLUGIN_UNINSTALL="Desinstalação do plugin Botão Adicionar Anexo concluída com sucesso."
+PLG_ADD_ATTACHMENT_BTN_PLUGIN_UPDATE="Atualização do plugin Botão Adicionar Anexo concluída com sucesso."

--- a/packages/add_attachment_btn_plugin/language/pt-BR/pt-BR.plg_editors-xtd_add_attachment.sys.ini
+++ b/packages/add_attachment_btn_plugin/language/pt-BR/pt-BR.plg_editors-xtd_add_attachment.sys.ini
@@ -1,0 +1,3 @@
+; Tradução para Português do Brasil do plugin Botão Adicionar Anexo
+ATTACH_ADD_ATTACHMENT_BUTTON_PLUGIN_DESCRIPTION="O plugin Botão Adicionar Anexo adiciona um botão ao editor de artigos/categorias que permite adicionar um anexo enquanto edita o artigo ou categoria."
+PLG_EDITORS-XTD_ADD_ATTACHMENT_BTN="Botão do Editor - Adicionar Anexo"

--- a/packages/attachments_component/admin/access.xml
+++ b/packages/attachments_component/admin/access.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<access component="com_attachments">
+	<section name="component">
+		<action name="core.admin" title="ATTACH_PERMISSION_ADMIN_COMPONENT"
+			description="ATTACH_PERMISSION_ADMIN_COMPONENT_DESC" />
+
+		<action name="core.manage" title="ATTACH_PERMISSION_MANAGE_COMPONENT"
+			description="ATTACH_PERMISSION_MANAGE_COMPONENT_DESC" />
+
+		<action name="core.create" title="ATTACH_PERMISSION_CREATE"
+			description="ATTACH_PERMISSION_CREATE_DESC" />
+
+		<action name="core.delete" title="ATTACH_PERMISSION_DELETE"
+			description="ATTACH_PERMISSION_DELETE_DESC" />
+
+		<action name="core.edit" title="ATTACH_PERMISSION_EDIT"
+			description="ATTACH_PERMISSION_EDIT_DESC" />
+
+		<action name="core.edit.state" title="ATTACH_PERMISSION_EDITSTATE"
+			description="ATTACH_PERMISSION_EDITSTATE_DESC" />
+
+		<action name="core.edit.own" title="ATTACH_PERMISSION_EDITOWN"
+			description="ATTACH_PERMISSION_EDITOWN_DESC" />
+
+		<action name="attachments.edit.state.own" title="ATTACH_PERMISSION_EDITSTATE_OWN"
+			description="ATTACH_PERMISSION_EDITSTATE_OWN_DESC" />
+
+		<action name="attachments.delete.own" title="ATTACH_PERMISSION_DELETEOWN"
+			description="ATTACH_PERMISSION_DELETEOWN_DESC" />
+
+		<action name="attachments.edit.ownparent" title="ATTACH_PERMISSION_EDIT_OWNPARENT"
+			description="ATTACH_PERMISSION_EDIT_OWNPARENT_DESC" />
+
+		<action name="attachments.edit.state.ownparent" title="ATTACH_PERMISSION_EDITSTATE_OWNPARENT"
+			description="ATTACH_PERMISSION_EDITSTATE_OWNPARENT_DESC" />
+
+		<action name="attachments.delete.ownparent" title="ATTACH_PERMISSION_DELETE_OWNPARENT"
+			description="ATTACH_PERMISSION_DELETE_OWNPARENT_DESC" />
+	</section>
+</access>

--- a/packages/attachments_component/admin/attachments.xml
+++ b/packages/attachments_component/admin/attachments.xml
@@ -1,0 +1,232 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension type="component" version="4.0" method="upgrade">
+    <name>com_attachments</name>
+    <version>4.1.6</version>
+    <creationDate>August  1, 2025</creationDate>
+    <author>Jonathan M. Cameron</author>
+    <authorEmail>jmcameron@jmcameron.net</authorEmail>
+    <authorUrl>https://github.com/jmcameron/attachments</authorUrl>
+    <copyright>(C) 2007-2025 Jonathan M. Cameron. All rights reserved.</copyright>
+    <license>http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL</license>
+    <description>ATTACH_ATTACHMENTS_COMPONENT_DESCRIPTION</description>
+
+    <scriptfile>install.attachments.php</scriptfile>
+
+    <install>
+	<sql>
+	    <file driver="mysql" charset="utf8">sql/install.mysql.sql</file>
+	</sql>
+    </install>
+
+    <update>
+        <schemas>
+            <schemapath type="mysql">sql/updates/mysql</schemapath>
+        </schemas>
+    </update>
+
+    <uninstall>
+	<sql>
+	    <file driver="mysql" charset="utf8">sql/uninstall.mysql.sql</file>
+	</sql>
+    </uninstall>
+
+	<namespace path="src/">JMCameron\Component\Attachments</namespace>
+
+    <files folder="site">
+	<filename>index.html</filename>
+	<filename>router.php</filename>
+	<filename>src/Model/AttachmentModel.php</filename>
+	<filename>src/Model/AttachmentsModel.php</filename>
+	<filename>src/Model/index.html</filename>
+	<filename>src/Controller/AttachmentsController.php</filename>
+	<filename>src/Controller/DisplayController.php</filename>
+	<filename>src/Controller/index.html</filename>
+	<filename>src/Helper/AttachmentsDefines.php</filename>
+	<filename>src/Helper/AttachmentsHelper.php</filename>
+	<filename>src/Helper/AttachmentsJavascript.php</filename>
+	<filename>src/Helper/AttachmentsFileTypes.php</filename>
+	<filename>src/index.html</filename>
+	<filename>src/View/Warning/HtmlView.php</filename>
+	<filename>src/View/Warning/index.html</filename>
+	<filename>src/View/Upload/metadata.xml</filename>
+	<filename>src/View/Upload/HtmlView.php</filename>
+	<filename>src/View/Upload/index.html</filename>
+	<filename>src/View/Login/HtmlView.php</filename>
+	<filename>src/View/Login/index.html</filename>
+	<filename>src/View/AttachmentsFormView.php</filename>
+	<filename>src/View/Attachments/metadata.xml</filename>
+	<filename>src/View/Attachments/RawView.php</filename>
+	<filename>src/View/Attachments/HtmlView.php</filename>
+	<filename>src/View/Attachments/index.html</filename>
+	<filename>src/View/Update/metadata.xml</filename>
+	<filename>src/View/Update/HtmlView.php</filename>
+	<filename>src/View/Update/index.html</filename>
+	<filename>tmpl/attachments/default.xml</filename>
+	<filename>tmpl/attachments/index.html</filename>
+	<filename>tmpl/attachments/default.php</filename>
+	<filename>tmpl/login/index.html</filename>
+	<filename>tmpl/login/default.php</filename>
+	<filename>tmpl/index.html</filename>
+	<filename>tmpl/update/index.html</filename>
+	<filename>tmpl/update/default.php</filename>
+	<filename>tmpl/warning/index.html</filename>
+	<filename>tmpl/warning/default.php</filename>
+	<filename>tmpl/upload/index.html</filename>
+	<filename>tmpl/upload/default.php</filename>
+	<folder>language</folder>
+    </files>
+
+    <administration>
+	<menu img="../media/com_attachments/images/attachments.png">ATTACH_ATTACHMENTS</menu>
+	<submenu>
+	     <menu link="option=com_attachments" img="class:icon-attachments">ATTACH_ATTACHMENTS</menu>
+	     <menu link="option=com_attachments&amp;task=attachment.add" img="class:newarticle">ATTACH_ADD_NEW_ATTACHMENT</menu>
+	     <menu link="option=com_attachments&amp;task=params.edit" img="class:config">JTOOLBAR_OPTIONS</menu>
+	</submenu>
+
+	<files folder="admin">
+	    <filename>attachments.php</filename>
+	    <filename>access.xml</filename>
+	    <filename>config.xml</filename>
+	    <filename>index.html</filename>
+	    <filename>forms/index.html</filename>
+	    <filename>forms/attachment.xml</filename>
+	    <filename>sql/index.html</filename>
+	    <filename>sql/install.mysql.sql</filename>
+	    <filename>sql/uninstall.mysql.sql</filename>
+		<filename>services/provider.php</filename>
+		<filename>tmpl/utils/index.html</filename>
+		<filename>tmpl/utils/default.php</filename>
+		<filename>tmpl/attachments/default_body.php</filename>
+		<filename>tmpl/attachments/default_filter.php</filename>
+		<filename>tmpl/attachments/default_head.php</filename>
+		<filename>tmpl/attachments/index.html</filename>
+		<filename>tmpl/attachments/default_foot.php</filename>
+		<filename>tmpl/attachments/default.php</filename>
+		<filename>tmpl/entity/index.html</filename>
+		<filename>tmpl/entity/default.php</filename>
+		<filename>tmpl/params/index.html</filename>
+		<filename>tmpl/params/default.php</filename>
+		<filename>tmpl/index.html</filename>
+		<filename>tmpl/add/index.html</filename>
+		<filename>tmpl/add/default.php</filename>
+		<filename>tmpl/help/index.html</filename>
+		<filename>tmpl/help/default.php</filename>
+		<filename>tmpl/edit/index.html</filename>
+		<filename>tmpl/edit/default.php</filename>
+		<filename>tmpl/warning/index.html</filename>
+		<filename>tmpl/warning/default.php</filename>
+		<filename>src/Model/AttachmentModel.php</filename>
+		<filename>src/Model/AttachmentsModel.php</filename>
+		<filename>src/Model/index.html</filename>
+		<filename>src/Controller/DisplayController.php</filename>
+		<filename>src/Controller/SpecialController.php</filename>
+		<filename>src/Controller/AttachmentsController.php</filename>
+		<filename>src/Controller/ListController.php</filename>
+		<filename>src/Controller/ParamsController.php</filename>
+		<filename>src/Controller/AttachmentController.php</filename>
+		<filename>src/Controller/index.html</filename>
+		<filename>src/Controller/UtilsController.php</filename>
+		<filename>src/Field/IconfilenamesField.php</filename>
+		<filename>src/Field/AccessLevelsField.php</filename>
+		<filename>src/Field/index.html</filename>
+		<filename>src/index.html</filename>
+		<filename>src/Helper/AttachmentsPermissions.php</filename>
+	    <filename>src/Helper/AttachmentsImport.php</filename>
+	    <filename>src/Helper/AttachmentsUpdate.php</filename>
+	    <filename>src/Helper/ImportArticles.php</filename>
+	    <filename>src/Helper/ImportAttachments.php</filename>
+	    <filename>src/Helper/ImportFromCSV.php</filename>
+		<filename>src/Table/AttachmentTable.php</filename>
+		<filename>src/Table/index.html</filename>
+		<filename>src/View/Warning/HtmlView.php</filename>
+		<filename>src/View/Warning/index.html</filename>
+		<filename>src/View/Edit/HtmlView.php</filename>
+		<filename>src/View/Edit/index.html</filename>
+		<filename>src/View/Entity/HtmlView.php</filename>
+		<filename>src/View/Entity/index.html</filename>
+		<filename>src/View/Add/HtmlView.php</filename>
+		<filename>src/View/Add/index.html</filename>
+		<filename>src/View/Attachments/HtmlView.php</filename>
+		<filename>src/View/Attachments/index.html</filename>
+		<filename>src/View/Help/HtmlView.php</filename>
+		<filename>src/View/Help/index.html</filename>
+		<filename>src/View/Help/HelpView.php</filename>
+		<filename>src/View/Utils/HtmlView.php</filename>
+		<filename>src/View/Utils/index.html</filename>
+		<filename>src/View/Params/HtmlView.php</filename>
+		<filename>src/View/Params/index.html</filename>
+	    <filename>Changelog.php</filename>
+	    <folder>sql/updates</folder>
+	    <folder>language</folder>
+	</files>
+
+	<languages>
+		<language tag="en-GB">admin/language/en-GB/en-GB.com_attachments.sys.ini</language>
+		<language tag="en-GB">admin/language/en-GB/en-GB.com_attachments.ini</language>
+		<language tag="en-GB">admin/language/en-GB/en-GB.com_attachments.help.ini</language>
+		<language tag="el-GR">admin/language/el-GR/el-GR.com_attachments.sys.ini</language>
+		<language tag="el-GR">admin/language/el-GR/el-GR.com_attachments.ini</language>
+		<language tag="fr-FR">admin/language/fr-FR/fr-FR.com_attachments.sys.ini</language>
+		<language tag="fr-FR">admin/language/fr-FR/fr-FR.com_attachments.ini</language>
+	</languages>
+    </administration>
+
+    <media destination="com_attachments" folder="media">
+       <filename>index.html</filename>
+       <filename>css/index.html</filename>
+       <filename>css/add_attachment_button.css</filename>
+       <filename>css/add_attachment_button_rtl.css</filename>
+       <filename>css/attachments_admin.css</filename>
+       <filename>css/attachments_admin_dark.css</filename>
+       <filename>css/attachments_admin_form.css</filename>
+       <filename>css/attachments_admin_form_dark.css</filename>
+       <filename>css/attachments_admin_form_rtl.css</filename>
+       <filename>css/attachments_admin_rtl.css</filename>
+       <filename>css/attachments_admin_utils.css</filename>
+       <filename>css/attachments_admin_utils_rtl.css</filename>
+       <filename>css/attachments_frontend_form.css</filename>
+       <filename>css/attachments_frontend_form_rtl.css</filename>
+       <filename>css/attachments_hide.css</filename>
+       <filename>css/attachments_help.css</filename>
+       <filename>css/attachments_list.css</filename>
+       <filename>css/attachments_list_dark.css</filename>
+       <filename>css/attachments_list_rtl.css</filename>
+       <filename>css/attachments_quickicon.css</filename>
+       <filename>css/insert_attachments_token_button.css</filename>
+       <filename>css/insert_attachments_token_button_rtl.css</filename>
+       <filename>images/index.html</filename>
+       <filename>images/add_attachment.gif</filename>
+       <filename>images/add_attachment_button.png</filename>
+       <filename>images/add_attachment_button_rtl.png</filename>
+       <filename>images/add_attachment_button_small.png</filename>
+       <filename>images/add_attachment_button_small_rtl.png</filename>
+       <filename>images/attachment.gif</filename>
+       <filename>images/attachments.png</filename>
+       <filename>images/attachments_help_logo32.png</filename>
+       <filename>images/attachments_logo32.png</filename>
+       <filename>images/attachments_logo48.png</filename>
+       <filename>images/attachments_utils32.png</filename>
+       <filename>images/delete.gif</filename>
+       <filename>images/download.gif</filename>
+       <filename>images/insert_attachments_token_button.png</filename>
+       <filename>images/insert_attachments_token_button_rtl.png</filename>
+       <filename>images/insert_attachments_token_button_small.png</filename>
+       <filename>images/insert_attachments_token_button_small_rtl.png</filename>
+       <filename>images/pencil.gif</filename>
+       <filename>images/update.gif</filename>
+       <filename>js/index.html</filename>
+       <filename>js/attachments_caching.js</filename>
+       <filename>js/attachments_refresh.js</filename>
+       <folder>images/file_icons</folder>
+       <folder>images/help</folder>
+    </media>
+
+    <!-- Install the package language file this way since it is not clear how to install it directly with the package installer -->
+    <languages>
+		<language tag="en-GB">site/language/en-GB/en-GB.com_attachments.ini</language>
+    	<language tag="el-GR">site/language/el-GR/el-GR.com_attachments.ini</language>
+		<language tag="fr-FR">site/language/fr-FR/fr-FR.com_attachments.ini</language>
+	</languages>
+
+</extension>

--- a/packages/attachments_component/admin/config.xml
+++ b/packages/attachments_component/admin/config.xml
@@ -1,0 +1,294 @@
+<?xml version="1.0" encoding="utf-8"?>
+<config>
+  <inlinehelp button="show" />
+  <fieldset name="basic" id="attachments-fieldset"
+	    label="ATTACH_CONFIG_BASIC_SETTINGS_LABEL"
+	    addfieldprefix="JMCameron\Component\Attachments\Administrator\Field"
+	    >
+    <field name="publish_default" type="radio" default="0" layout="joomla.form.field.radio.switcher"
+           label="ATTACH_ATTACHMENTS_PUBLISHED_BY_DEFAULT"
+           description="ATTACH_ATTACHMENTS_PUBLISHED_BY_DEFAULT_DESCRIPTION">
+      <option value="0">JNO</option>
+      <option value="1">JYES</option>
+    </field>
+    <field name="auto_publish_warning" type="textarea" default=""
+           label="ATTACH_AUTO_PUBLISH_WARNING" rows="2" cols="60"
+           description="ATTACH_AUTO_PUBLISH_WARNING_DESCRIPTION">
+    </field>
+    <field name="default_access_level" type="accessLevels" default="2"
+	   label="ATTACH_DEFAULT_ACCESS_LEVEL" class="form-select"
+	   description="ATTACH_DEFAULT_ACCESS_LEVEL_DESCRIPTION"
+	   />
+    <field name="user_field_1_name" type="text" default=""
+           label="ATTACH_USER_DEFINED_FIELD_1_NAME" size="40"
+           description="ATTACH_USER_DEFINED_FIELD_NAME_DESCRIPTION">
+    </field>
+    <field name="user_field_2_name" type="text" default=""
+           label="ATTACH_USER_DEFINED_FIELD_2_NAME" size="40"
+           description="ATTACH_USER_DEFINED_FIELD_NAME_DESCRIPTION">
+    </field>
+    <field name="user_field_3_name" type="text" default=""
+           label="ATTACH_USER_DEFINED_FIELD_3_NAME" size="40"
+           description="ATTACH_USER_DEFINED_FIELD_NAME_DESCRIPTION">
+    </field>
+    <field name="max_filename_length" type="text" default="0"
+           label="ATTACH_MAX_FILENAME_URL_LENGTH" size="2" filter="integer"
+           description="ATTACH_MAX_FILENAME_URL_LENGTH_DESCRIPTION">
+    </field>
+    <field name="attachments_placement" type="list" default="end"
+           label="ATTACH_WHERE_SHOULD_ATTACHMENTS_BE_PLACED"
+           description="ATTACH_WHERE_SHOULD_ATTACHMENTS_BE_PLACED_DESCRIPTION">
+      <option value="beginning">ATTACH_AT_THE_BEGINNING</option>
+      <option value="end">ATTACH_AT_THE_END</option>
+      <option value="custom">ATTACH_CUSTOM_PLACEMENT</option>
+      <option value="disabled_filter">ATTACH_DISABLED_FILTER</option>
+      <option value="disabled_nofilter">ATTACH_DISABLED_NOFILTER</option>
+    </field>
+    <field name="allow_frontend_access_editing" type="radio" default="0" layout="joomla.form.field.radio.switcher"
+           label="ATTACH_ALLOW_FRONTEND_ACCESS_LEVEL_EDITING"
+           description="ATTACH_ALLOW_FRONTEND_ACCESS_LEVEL_EDITING_DESCRIPTION">
+      <option value="0">JNO</option>
+      <option value="1">JYES</option>
+    </field>
+  </fieldset>
+
+  <fieldset name="formatting"
+	    label="ATTACH_CONFIG_FORMATTING_SETTINGS_LABEL">
+    <field name="show_column_titles" type="radio" default="0" layout="joomla.form.field.radio.switcher"
+           label="ATTACH_SHOW_COLUMN_TITLES"
+           description="ATTACH_SHOW_COLUMN_TITLES_DESCRIPTION">
+      <option value="0">JNO</option>
+      <option value="1">JYES</option>
+    </field>
+    <field name="show_description" type="radio" default="1" layout="joomla.form.field.radio.switcher"
+           label="ATTACH_SHOW_ATTACHMENT_DESCRIPTION"
+           description="ATTACH_SHOW_ATTACHMENT_DESCRIPTION_DESCRIPTION">
+      <option value="0">JNO</option>
+      <option value="1">JYES</option>
+    </field>
+    <field name="hide_brackets_if_empty" type="radio" default="0" layout="joomla.form.field.radio.switcher"
+           label="ATTACH_HIDE_BRACKETS_IF_EMPTY"
+           description="ATTACH_HIDE_BRACKETS_IF_EMPTY_DESCRIPTION">
+      <option value="0">JNO</option>
+      <option value="1">JYES</option>
+    </field>
+
+    <field name="show_creator_name" type="radio" default="0" layout="joomla.form.field.radio.switcher"
+           label="ATTACH_SHOW_ATTACHMENT_CREATOR"
+           description="ATTACH_SHOW_ATTACHMENT_CREATOR_DESCRIPTION">
+      <option value="0">JNO</option>
+      <option value="1">JYES</option>
+    </field>
+    <field name="show_file_size" type="radio" default="1" layout="joomla.form.field.radio.switcher"
+           label="ATTACH_SHOW_ATTACHMENT_FILE_SIZE"
+           description="ATTACH_SHOW_ATTACHMENT_FILE_SIZE_DESCRIPTION">
+      <option value="0">JNO</option>
+      <option value="1">JYES</option>
+    </field>
+    <field name="show_downloads" type="radio" default="0" layout="joomla.form.field.radio.switcher"
+           label="ATTACH_SHOW_NUMBER_OF_DOWNLOADS"
+           description="ATTACH_SHOW_NUMBER_OF_DOWNLOADS_DESCRIPTION">
+      <option value="0">JNO</option>
+      <option value="1">JYES</option>
+    </field>
+    <field name="show_created_date" type="radio" default="0" layout="joomla.form.field.radio.switcher"
+           label="ATTACH_SHOW_CREATION_DATE"
+           description="ATTACH_SHOW_CREATION_DATE_DESCRIPTION">
+      <option value="0">JNO</option>
+      <option value="1">JYES</option>
+    </field>
+    <field name="show_modified_date" type="radio" default="0" layout="joomla.form.field.radio.switcher"
+           label="ATTACH_SHOW_MODIFICATION_DATE"
+           description="ATTACH_SHOW_MODIFICATION_DATE_DESCRIPTION">
+      <option value="0">JNO</option>
+      <option value="1">JYES</option>
+    </field>
+    <field name="date_format" type="text" default="Y-m-d H:i"
+           label="ATTACH_FORMAT_STRING_FOR_DATES" size="30"
+           description="ATTACH_FORMAT_STRING_FOR_DATES_DESCRIPTION">
+    </field>
+    <field name="use_fontawesome_icons" type="radio" default="0" layout="joomla.form.field.radio.switcher"
+           label="ATTACH_SHOW_FONTAWESOME_ICONS"
+           description="ATTACH_SHOW_FONTAWESOME_ICONS_DESCRIPTION">
+      <option value="0">JNO</option>
+      <option value="1">JYES</option>
+    </field>
+    <field name="use_fontawesome_icons_style" type="list" default="fas"
+           label="ATTACH_SHOW_FONTAWESOME_ICONS_STYLE"
+           description="ATTACH_SHOW_FONTAWESOME_ICONS_STYLE_DESCRIPTION"
+           showon="use_fontawesome_icons:1">
+      <option value="fas">ATTACH_SHOW_FONTAWESOME_ICONS_STYLE_FAS</option>
+      <option value="far">ATTACH_SHOW_FONTAWESOME_ICONS_STYLE_FAR</option>
+      <option value="fal">ATTACH_SHOW_FONTAWESOME_ICONS_STYLE_FAL</option>
+      <option value="fad">ATTACH_SHOW_FONTAWESOME_ICONS_STYLE_FAD</option>
+    </field>
+    <field name="sort_order" type="list" default="filename"
+           label="ATTACH_ATTACHMENTS_LIST_ORDER"
+           description="ATTACH_ATTACHMENTS_LIST_ORDER_DESCRIPTION">
+      <option value="filename">ATTACH_SORT_FILENAME</option>
+      <option value="filename_desc">ATTACH_SORT_FILENAME_DESCENDING</option>
+      <option value="file_size">ATTACH_SORT_FILE_SIZE</option>
+      <option value="file_size_desc">ATTACH_SORT_FILE_SIZE_DESCENDING</option>
+      <option value="description">ATTACH_SORT_DESCRIPTION</option>
+      <option value="description_desc">ATTACH_SORT_DESCRIPTION_DESCENDING</option>
+      <option value="display_name">ATTACH_SORT_DISPLAY_FILENAME_OR_URL</option>
+      <option value="display_name_desc">ATTACH_SORT_DISPLAY_FILENAME_OR_URL_DESCENDING</option>
+      <option value="creator">ATTACH_CREATOR</option>
+      <option value="created">ATTACH_SORT_CREATED_DATE</option>
+      <option value="created_desc">ATTACH_SORT_CREATED_DATE_DESCENDING</option>
+      <option value="modified">ATTACH_SORT_MODIFICATION_DATE</option>
+      <option value="modified_desc">ATTACH_SORT_MODIFICATION_DATE_DESCENDING</option>
+      <option value="id">ATTACH_SORT_ATTACHMENT_ID</option>
+      <option value="user_field_1">ATTACH_USER_DEFINED_FIELD_1</option>
+      <option value="user_field_1_desc">ATTACH_SORT_USER_DEFINED_FIELD_1_DESC</option>
+      <option value="user_field_2">ATTACH_USER_DEFINED_FIELD_2</option>
+      <option value="user_field_2_desc">ATTACH_SORT_USER_DEFINED_FIELD_2_DESC</option>
+      <option value="user_field_3">ATTACH_USER_DEFINED_FIELD_3</option>
+      <option value="user_field_3_desc">ATTACH_SORT_USER_DEFINED_FIELD_3_DESC</option>
+    </field>
+  </fieldset>
+
+  <fieldset name="visibility"
+	    label="ATTACH_CONFIG_VISIBILITY_SETTINGS_LABEL">
+    <field name="hide_on_frontpage" type="radio" default="0" layout="joomla.form.field.radio.switcher"
+           label="ATTACH_HIDE_ATTACHMENTS_ON_FRONTPAGE"
+           description="ATTACH_HIDE_ATTACHMENTS_ON_FRONTPAGE_DESCRIPTION">
+      <option value="0">JNO</option>
+      <option value="1">JYES</option>
+    </field>
+    <field name="hide_with_readmore" type="radio" default="0" layout="joomla.form.field.radio.switcher"
+           label="ATTACH_HIDE_ATTACHMENTS_WITH_READMORE"
+           description="ATTACH_HIDE_ATTACHMENTS_WITH_READMORE_DESCRIPTION">
+      <option value="0">JNO</option>
+      <option value="1">JYES</option>
+    </field>
+    <field name="hide_on_blogs" type="radio" default="0" layout="joomla.form.field.radio.switcher"
+           label="ATTACH_HIDE_ATTACHMENTS_ON_BLOGS"
+           description="ATTACH_HIDE_ATTACHMENTS_ON_BLOGS_DESCRIPTION">
+      <option value="0">JNO</option>
+      <option value="1">JYES</option>
+    </field>
+    <field name="hide_except_article_views" type="radio" default="0" layout="joomla.form.field.radio.switcher"
+           label="ATTACH_HIDE_ATTACHMENTS_EXCEPT_ON_ARTICLE_VIEWS"
+           description="ATTACH_HIDE_ATTACHMENTS_EXCEPT_ON_ARTICLE_VIEWS_DESCRIPTION">
+      <option value="0">JNO</option>
+      <option value="1">JYES</option>
+    </field>
+    <field name="always_show_category_attachments" type="radio" default="0" layout="joomla.form.field.radio.switcher"
+           label="ATTACH_ALWAYS_SHOW_CATEGORY_ATTACHMENTS"
+           description="ATTACH_ALWAYS_SHOW_CATEGORY_ATTACHMENTS_DESCRIPTION">
+      <option value="0">JNO</option>
+      <option value="1">JYES</option>
+    </field>
+    <field name="hide_attachments_for_categories" type="category" default=""
+           label="ATTACH_HIDE_ATTACHMENTS_FOR_CATEGORIES" size="8"
+           extension="com_content" multiple="multiple"
+           description="ATTACH_HIDE_ATTACHMENTS_FOR_CATEGORIES_DESCRIPTION">
+    </field>
+    <field name="show_guest_access_levels" type="accessLevels" default="[1]"
+	   extension="com_attachments" multiple="multiple" size="3"
+	   label="ATTACH_SHOW_GUEST_ACCESS_LEVELS" class="form-select"
+	   description="ATTACH_SHOW_GUEST_ACCESS_LEVELS_DESCRIPTION"
+	   />
+    <field name="hide_add_attachments_link" type="radio" default="0" layout="joomla.form.field.radio.switcher"
+           label="ATTACH_HIDE_ADD_ATTACHMENTS_LINK"
+           description="ATTACH_HIDE_ADD_ATTACHMENTS_LINK_DESCRIPTION">
+      <option value="0">JNO</option>
+      <option value="1">JYES</option>
+    </field>
+  </fieldset>
+
+  <fieldset name="advanced"
+	    label="ATTACH_CONFIG_ADVANCED_SETTINGS_LABEL">
+    <field name="max_attachment_size" type="text" size="50" default="0" filter="integer"
+	   label="ATTACH_MAX_ATTACHMENT_SIZE" 
+	   description="ATTACH_MAX_ATTACHMENT_SIZE_DESCRIPTION" />
+    <field name="forbidden_filename_characters" type="text" default="#=?%&amp;"
+           label="ATTACH_FORBIDDEN_FILENAME_CHARACTERS" size="40"
+           description="ATTACH_FORBIDDEN_FILENAME_CHARACTERS_DESCRIPTION">
+    </field>
+    <field name="sanitize_filename_characters"  type="radio" default="0" layout="joomla.form.field.radio.switcher"
+           label="ATTACH_SANITIZE_FILENAME"
+           description="ATTACH_SANITIZE_FILENAME_DESCRIPTION">
+      <option value="0">JNO</option>
+      <option value="1">JYES</option>
+    </field>
+    <field name="attachments_table_style" type="text" default="attachmentsList"
+           label="ATTACH_CSS_STYLE_FOR_ATTACHMENTS_TABLES" size="40"
+           description="ATTACH_CSS_STYLE_FOR_ATTACHMENTS_TABLES_DESCRIPTION">
+    </field>
+    <field name="file_link_open_mode" type="list" default="in_same_window"
+           label="ATTACH_FILE_LINK_OPEN_MODE"
+           description="ATTACH_FILE_LINK_OPEN_MODE_DESCRIPTION">
+      <option value="new_window">ATTACH_IN_NEW_WINDOW</option>
+      <option value="in_same_window">ATTACH_IN_SAME_WINDOW</option>
+      <option value="in_a_popup">ATTACH_IN_A_POPUP</option>
+    </field>
+    <field name="attachments_titles" type="textarea" default=""
+           label="ATTACH_CUSTOM_TITLES_FOR_ATTACHMENTS_LISTS" rows="3" cols="60"
+           description="ATTACH_CUSTOM_TITLES_FOR_ATTACHMENTS_LISTS_DESCRIPTION">
+    </field>
+    <field name="link_check_timeout" type="text" default="10"
+           label="ATTACH_TIMEOUT_FOR_CHECKING_LINKS" size="3"
+           description="ATTACH_TIMEOUT_FOR_CHECKING_LINKS_DESCRIPTION">
+    </field>
+    <field name="superimpose_url_link_icons" type="radio" default="1" layout="joomla.form.field.radio.switcher"
+           label="ATTACH_SUPERIMPOSE_URL_LINK_ICONS"
+           description="ATTACH_SUPERIMPOSE_URL_LINK_ICONS_DESCRIPTION">
+      <option value="0">JNO</option>
+      <option value="1">JYES</option>
+    </field>
+    <field name="suppress_obsolete_attachments" type="radio" default="0" layout="joomla.form.field.radio.switcher"
+           label="ATTACH_SUPPRESS_OBSOLETE_ATTACHMENTS"
+           description="ATTACH_SUPPRESS_OBSOLETE_ATTACHMENTS_DESCRIPTION">
+      <option value="0">JNO</option>
+      <option value="1">JYES</option>
+    </field>
+    <field name="login_url" type="text"
+           default="index.php?option=com_users&amp;view=login"
+           label="ATTACH_URL_TO_LOGIN" size="65"
+           description="ATTACH_URL_TO_LOGIN_DESCRIPTION">
+    </field>
+    <field name="register_url" type="text"
+           default="index.php?option=com_users&amp;view=registration"
+           label="ATTACH_URL_TO_REGISTER" size="65"
+           description="ATTACH_URL_TO_REGISTER_DESCRIPTION">
+    </field>
+
+  </fieldset>
+
+  <fieldset name="security"
+	    label="ATTACH_CONFIG_SECURITY_SETTINGS_LABEL">
+    <field name="secure" type="radio" default="0" layout="joomla.form.field.radio.switcher"
+           label="ATTACH_SECURE_ATTACHMENT_DOWNLOADS"
+           description="ATTACH_SECURE_ATTACHMENT_DOWNLOADS_DESCRIPTION">
+      <option value="0">JNO</option>
+      <option value="1">JYES</option>
+    </field>
+    <field name="download_mode" type="radio" default="inline" layout="joomla.form.field.radio.switcher"
+           label="ATTACH_DOWNLOAD_MODE_FOR_SECURE_DOWNLOADS"
+           description="ATTACH_DOWNLOAD_MODE_FOR_SECURE_DOWNLOADS_DESCRIPTION">
+      <option value="attachment">ATTACH_ATTACHMENT</option>
+      <option value="inline">ATTACH_INLINE</option>
+    </field>
+    <field name="show_raw_download" type="radio" default="0" layout="joomla.form.field.radio.switcher"
+           label="ATTACH_SHOW_RAW_DOWNLOAD"
+           description="ATTACH_SHOW_RAW_DOWNLOAD_DESCRIPTION"
+           showon="file_link_open_mode:in_a_popup">
+      <option value="0">JNO</option>
+      <option value="1">JYES</option>
+    </field>
+  </fieldset>
+
+  <fieldset name="permissions"
+            label="JCONFIG_PERMISSIONS_LABEL"
+            description="ATTACH_PERMISSIONS_DESC">
+    <field name="rules" type="rules"
+           component="com_attachments"
+           filter="rules"
+           validate="rules"
+           label="JCONFIG_PERMISSIONS_LABEL"
+           section="component" />
+  </fieldset>
+
+</config>

--- a/packages/attachments_component/admin/forms/attachment.xml
+++ b/packages/attachments_component/admin/forms/attachment.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8"?>
+<form>
+    <fieldset>
+        <field name="id" type="text" default="0"
+               label="ATTACH_ATTACHMENT_ID" description="ATTACH_ATTACHMENT_ID_DESCRIPTION"
+               readonly="true" class="readonly"
+        />
+        <field name="state" type="radio" default="0"
+               label="JPUBLISHED" description="">
+            <option value="0">JNO</option>
+            <option value="1">JYES</option>
+        </field>
+        <field name="parent_type" type="text"
+               label="ATTACH_PARENT_TYPE" description="ATTACH_PARENT_TYPE_DESCRIPTION"
+               readonly="true" class="readonly"
+        />
+        <field name="parent_entity" type="text"
+               label="ATTACH_PARENT_ENTITY" description="ATTACH_PARENT_ENTITY_DESCRIPTION"
+               readonly="true" class="readonly"
+        />
+        <field name="parent_id" type="text"
+               label="ATTACH_PARENT_ID" description="ATTACH_PARENT_ID_DESCRIPTION"
+               readonly="true" class="readonly"
+        />
+        <field name="filename" type="file"
+               label="ATTACH_FILENAME" description="ATTACH_FILENAME_DESCRIPTION"
+        />
+        <field name="filename_sys" type="text"
+               label="ATTACH_SYSTEM_FILENAME" description="ATTACH_SYSTEM_FILENAME_DESCRIPTION"
+               readonly="true" class="readonly"
+        />
+        <field name="file_type" type="text"
+               label="ATTACH_FILE_TYPE" description="ATTACH_FILE_TYPE_DESCRIPTION"
+               readonly="true" class="readonly"
+               size="70"
+        />
+        <field name="file_size" type="text"
+               label="ATTACH_FILE_SIZE_KB" description=""
+               readonly="true" class="readonly"
+        />
+        <field name="icon_filename" type="Iconfilenames"
+               label="ATTACH_ICON_FILENAME" description="ATTACH_ICON_FILENAME_DESCRIPTION"
+        />
+        <field name="uri_type" type="text"
+               label="ATTACH_ATTACHMENT_TYPE" description=""
+               readonly="true" class="readonly"
+               size="10"
+        />
+        <field name="url" type="text"
+               readonly="true" class="readonly"
+               label="ATTACH_URL" description="ATTACH_URL_DESCRIPTION"
+               size="70"
+        />
+        <field name="url_valid" type="radio"
+               label="ATTACH_URL_IS_VALID" description="ATTACH_URL_IS_VALID_TOOLTIP"
+               default="1">
+            <option value="0">JNO</option>
+            <option value="1">JYES</option>
+        </field>
+        <field name="url_relative" type="radio"
+               label="ATTACH_RELATIVE_URL" description="ATTACH_RELATIVE_URL_TOOLTIP"
+               default="0">
+            <option value="0">JNO</option>
+            <option value="1">JYES</option>
+        </field>
+        <field name="display_name" type="text" class="inputbox"
+               label="ATTACH_DISPLAY_NAME" description="ATTACH_DISPLAY_NAME_DESCRIPTION"
+               size="80" maxlength="255"
+               default=""
+        />
+        <field name="user_field_1" type="text" class="inputbox"
+               label="ATTACH_USER_DEFINED_FIELD_1" description=""
+               size="80" maxlength="100"
+               default=""
+        />
+        <field name="user_field_2" type="text" class="inputbox"
+               label="ATTACH_USER_DEFINED_FIELD_2" description=""
+               size="80" maxlength="100"
+               default=""
+        />
+        <field name="user_field_3" type="text" class="inputbox"
+               label="ATTACH_USER_DEFINED_FIELD_3" description=""
+               size="80" maxlength="100"
+               default=""
+        />
+        <field name="description" type="text" class="inputbox"
+               label="ATTACH_DESCRIPTION" description="ATTACH_DESCRIPTION_DESCRIPTION"
+               size="80" maxlength="255"
+               default=""
+        />
+        <field name="created" type="Date"
+               label="ATTACH_DATE_CREATED" description=""
+               readonly="true" class="readonly"
+        />
+        <field name="modified" type="Date"
+               label="ATTACH_LAST_MODIFIED" description=""
+               readonly="true" class="readonly"
+        />
+        <field name="download_count" type="text"
+               label="ATTACH_NUMBER_OF_DOWNLOADS" description="ATTACH_NUMBER_OF_DOWNLOADS_TOOLTIP"
+               readonly="true" class="readonly"
+               size="10"
+        />
+        <field name="created_by" type="text"
+               label="ATTACH_CREATOR_ID" description=""
+               readonly="true" class="readonly"
+               size="10"
+        />
+    </fieldset>
+</form>

--- a/packages/attachments_component/admin/forms/filter_attachments.xml
+++ b/packages/attachments_component/admin/forms/filter_attachments.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<form>
+    <fields name="filter">
+        <field
+                name="search"
+                type="text"
+                inputmode="search"
+                label="ATTACH_FILTER_SEARCH_LABEL"
+                description="ATTACH_FILTER_SEARCH_DESC"
+                hint="JSEARCH_FILTER"
+        />
+        <field
+                name="state"
+                type="list"
+                label="JSTATUS"
+                description="JFIELD_PUBLISHED_DESC"
+                class="form-select-color-state"
+                default=""
+                validate="options"
+                onchange="this.form.submit();"
+        >
+            <option value="">JOPTION_SELECT_PUBLISHED</option>
+            <option value="1">JPUBLISHED</option>
+            <option value="0">JUNPUBLISHED</option>
+            <option value="*">JALL</option>
+        </field>
+
+        <field
+                name="parent_state"
+                type="list"
+                label="JSTATUS"
+                description="JFIELD_PUBLISHED_DESC"
+                class="form-select-color-state"
+                default=""
+                onchange="this.form.submit();"
+                validate="options"
+        >
+            <option value="">ATTACH_PARENTS_STATE</option>
+            <option value="PUBLISHED">ATTACH_PUBLISHED_PARENTS</option>
+            <option value="UNPUBLISHED">ATTACH_UNPUBLISHED_PARENTS</option>
+            <option value="ARCHIVED">ATTACH_ARCHIVED_PARENTS</option>
+            <option value="TRASHED">ATTACH_TRASHED_PARENTS</option>
+            <option value="NONE">ATTACH_NO_PARENTS</option>
+        </field>
+
+        <field
+                name="parent_entity"
+                type="list"
+                label="ATTACH_PARENT_TYPE"
+                description="ATTACH_PARENT_TYPE_DESCRIPTION"
+                default=""
+                filter="string"
+                onchange="this.form.submit();"
+                validate="options"
+        >
+            <option value="">ATTACH_PARENT_TYPE_SELECT</option>
+            <option value="com_content.article">ATTACH_ARTICLE</option>
+            <option value="com_content.category">ATTACH_CATEGORY</option>
+        </field>
+    </fields>
+    <fields name="list">
+        <field
+                name="fullordering"
+                type="list"
+                label="JGLOBAL_SORT_BY"
+                onchange="this.form.submit();"
+                default="a.name ASC"
+                validate="options"
+        >
+            <option value="">JGLOBAL_SORT_BY</option>
+            <option value="a.state ASC">JSTATUS_ASC</option>
+            <option value="a.state DESC">JSTATUS_DESC</option>
+            <option value="a.display_name ASC">ATTACH_DISPLAYNAME_ASC</option>
+            <option value="a.display_name DESC">ATTACH_DISPLAYNAME_DESC</option>
+            <option value="a.description ASC">ATTACH_DESCRIPTION_ASC</option>
+            <option value="a.description DESC">ATTACH_DESCRIPTION_DESC</option>
+            <option value="a.access ASC">JGRID_HEADING_ACCESS_ASC</option>
+            <option value="a.access DESC">JGRID_HEADING_ACCESS_DESC</option>
+            <option value="a.file_type ASC">ATTACH_FILE_TYPE_ASC</option>
+            <option value="a.file_type DESC">ATTACH_FILE_TYPE_DESC</option>
+            <option value="a.file_size ASC">ATTACH_FILE_SIZE_ASC</option>
+            <option value="a.file_size DESC">ATTACH_FILE_SIZE_DESC</option>
+            <option value="a.created ASC">JDATE_ASC</option>
+            <option value="a.created DESC">JDATE_DESC</option>
+            <option value="a.modified ASC">ATTACH_MODIFIED_ASC</option>
+            <option value="a.modified DESC">ATTACH_MODIFIED_DESC</option>
+            <option value="a.created_by ASC">JAUTHOR_ASC</option>
+            <option value="a.created_by DESC">JAUTHOR_DESC</option>
+            <option value="a.download_count ASC">ATTACH_DOWNLOADS_ASC</option>
+            <option value="a.download_count DESC">ATTACH_DOWNLOADS_DESC</option>
+            <option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
+            <option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
+        </field>
+        <field
+                name="limit"
+                type="limitbox"
+                label="JGLOBAL_LIST_LIMIT"
+                default="25"
+                onchange="this.form.submit();"
+        />
+    </fields>
+</form>

--- a/packages/attachments_component/attachments.xml
+++ b/packages/attachments_component/attachments.xml
@@ -1,0 +1,235 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension type="component" version="4.0" method="upgrade">
+    <name>com_attachments</name>
+    <version>4.1.6</version>
+    <creationDate>August  1, 2025</creationDate>
+    <author>Jonathan M. Cameron</author>
+    <authorEmail>jmcameron@jmcameron.net</authorEmail>
+    <authorUrl>https://github.com/jmcameron/attachments</authorUrl>
+    <copyright>(C) 2007-2025 Jonathan M. Cameron. All rights reserved.</copyright>
+    <license>https://www.gnu.org/licenses/gpl-3.0.html GNU/GPL</license>
+    <description>ATTACH_ATTACHMENTS_COMPONENT_DESCRIPTION</description>
+
+    <scriptfile>install.attachments.php</scriptfile>
+
+    <install>
+	<sql>
+	    <file driver="mysql" charset="utf8">sql/install.mysql.sql</file>
+	</sql>
+    </install>
+
+    <update>
+        <schemas>
+            <schemapath type="mysql">sql/updates/mysql</schemapath>
+        </schemas>
+    </update>
+
+    <uninstall>
+	<sql>
+	    <file driver="mysql" charset="utf8">sql/uninstall.mysql.sql</file>
+	</sql>
+    </uninstall>
+
+	<namespace path="src/">JMCameron\Component\Attachments</namespace>
+
+    <files folder="site">
+	<filename>index.html</filename>
+	<filename>router.php</filename>
+	<filename>src/Model/AttachmentModel.php</filename>
+	<filename>src/Model/AttachmentsModel.php</filename>
+	<filename>src/Model/index.html</filename>
+	<filename>src/Controller/AttachmentsController.php</filename>
+	<filename>src/Controller/DisplayController.php</filename>
+	<filename>src/Controller/index.html</filename>
+	<filename>src/Helper/AttachmentsDefines.php</filename>
+	<filename>src/Helper/AttachmentsHelper.php</filename>
+	<filename>src/Helper/AttachmentsJavascript.php</filename>
+	<filename>src/Helper/AttachmentsFileTypes.php</filename>
+	<filename>src/index.html</filename>
+	<filename>src/View/Warning/HtmlView.php</filename>
+	<filename>src/View/Warning/index.html</filename>
+	<filename>src/View/Upload/metadata.xml</filename>
+	<filename>src/View/Upload/HtmlView.php</filename>
+	<filename>src/View/Upload/index.html</filename>
+	<filename>src/View/Login/HtmlView.php</filename>
+	<filename>src/View/Login/index.html</filename>
+	<filename>src/View/AttachmentsFormView.php</filename>
+	<filename>src/View/Attachments/metadata.xml</filename>
+	<filename>src/View/Attachments/RawView.php</filename>
+	<filename>src/View/Attachments/HtmlView.php</filename>
+	<filename>src/View/Attachments/index.html</filename>
+	<filename>src/View/Update/metadata.xml</filename>
+	<filename>src/View/Update/HtmlView.php</filename>
+	<filename>src/View/Update/index.html</filename>
+	<filename>tmpl/attachments/default.xml</filename>
+	<filename>tmpl/attachments/index.html</filename>
+	<filename>tmpl/attachments/default.php</filename>
+	<filename>tmpl/login/index.html</filename>
+	<filename>tmpl/login/default.php</filename>
+	<filename>tmpl/index.html</filename>
+	<filename>tmpl/update/index.html</filename>
+	<filename>tmpl/update/default.php</filename>
+	<filename>tmpl/warning/index.html</filename>
+	<filename>tmpl/warning/default.php</filename>
+	<filename>tmpl/upload/index.html</filename>
+	<filename>tmpl/upload/default.php</filename>
+	<folder>language</folder>
+    </files>
+
+    <administration>
+	<menu img="../media/com_attachments/images/attachments.png">ATTACH_ATTACHMENTS</menu>
+	<submenu>
+	     <menu link="option=com_attachments" img="class:icon-attachments">ATTACH_ATTACHMENTS</menu>
+	     <menu link="option=com_attachments&amp;task=attachment.add" img="class:newarticle">ATTACH_ADD_NEW_ATTACHMENT</menu>
+	     <menu link="option=com_attachments&amp;task=params.edit" img="class:config">JTOOLBAR_OPTIONS</menu>
+	</submenu>
+
+	<files folder="admin">
+	    <filename>attachments.php</filename>
+	    <filename>access.xml</filename>
+	    <filename>config.xml</filename>
+	    <filename>index.html</filename>
+	    <filename>forms/index.html</filename>
+	    <filename>forms/attachment.xml</filename>
+		<filename>forms/filter_attachments.xml</filename>
+	    <filename>sql/index.html</filename>
+	    <filename>sql/install.mysql.sql</filename>
+	    <filename>sql/uninstall.mysql.sql</filename>
+		<filename>services/provider.php</filename>
+		<filename>tmpl/utils/index.html</filename>
+		<filename>tmpl/utils/default.php</filename>
+		<filename>tmpl/attachments/default_body.php</filename>
+		<filename>tmpl/attachments/default_filter.php</filename>
+		<filename>tmpl/attachments/default_head.php</filename>
+		<filename>tmpl/attachments/index.html</filename>
+		<filename>tmpl/attachments/default_foot.php</filename>
+		<filename>tmpl/attachments/default.php</filename>
+		<filename>tmpl/entity/index.html</filename>
+		<filename>tmpl/entity/default.php</filename>
+		<filename>tmpl/params/index.html</filename>
+		<filename>tmpl/params/default.php</filename>
+		<filename>tmpl/index.html</filename>
+		<filename>tmpl/add/index.html</filename>
+		<filename>tmpl/add/default.php</filename>
+		<filename>tmpl/help/index.html</filename>
+		<filename>tmpl/help/default.php</filename>
+		<filename>tmpl/edit/index.html</filename>
+		<filename>tmpl/edit/default.php</filename>
+		<filename>tmpl/warning/index.html</filename>
+		<filename>tmpl/warning/default.php</filename>
+		<filename>src/Model/AttachmentModel.php</filename>
+		<filename>src/Model/AttachmentsModel.php</filename>
+		<filename>src/Model/index.html</filename>
+		<filename>src/Controller/DisplayController.php</filename>
+		<filename>src/Controller/SpecialController.php</filename>
+		<filename>src/Controller/AttachmentsController.php</filename>
+		<filename>src/Controller/ListController.php</filename>
+		<filename>src/Controller/ParamsController.php</filename>
+		<filename>src/Controller/AttachmentController.php</filename>
+		<filename>src/Controller/index.html</filename>
+		<filename>src/Controller/UtilsController.php</filename>
+		<filename>src/Field/IconfilenamesField.php</filename>
+		<filename>src/Field/AccessLevelsField.php</filename>
+		<filename>src/Field/index.html</filename>
+		<filename>src/index.html</filename>
+		<filename>src/Helper/AttachmentsPermissions.php</filename>
+	    <filename>src/Helper/AttachmentsImport.php</filename>
+	    <filename>src/Helper/AttachmentsUpdate.php</filename>
+	    <filename>src/Helper/ImportArticles.php</filename>
+	    <filename>src/Helper/ImportAttachments.php</filename>
+	    <filename>src/Helper/ImportFromCSV.php</filename>
+		<filename>src/Table/AttachmentTable.php</filename>
+		<filename>src/Table/index.html</filename>
+		<filename>src/View/Warning/HtmlView.php</filename>
+		<filename>src/View/Warning/index.html</filename>
+		<filename>src/View/Edit/HtmlView.php</filename>
+		<filename>src/View/Edit/index.html</filename>
+		<filename>src/View/Entity/HtmlView.php</filename>
+		<filename>src/View/Entity/index.html</filename>
+		<filename>src/View/Add/HtmlView.php</filename>
+		<filename>src/View/Add/index.html</filename>
+		<filename>src/View/Attachments/HtmlView.php</filename>
+		<filename>src/View/Attachments/index.html</filename>
+		<filename>src/View/Help/HtmlView.php</filename>
+		<filename>src/View/Help/index.html</filename>
+		<filename>src/View/Help/HelpView.php</filename>
+		<filename>src/View/Utils/HtmlView.php</filename>
+		<filename>src/View/Utils/index.html</filename>
+		<filename>src/View/Params/HtmlView.php</filename>
+		<filename>src/View/Params/index.html</filename>
+	    <filename>Changelog.php</filename>
+	    <folder>sql/updates</folder>
+	    <folder>language</folder>
+	</files>
+
+	<languages>
+		<language tag="en-GB">admin/language/en-GB/en-GB.com_attachments.sys.ini</language>
+		<language tag="en-GB">admin/language/en-GB/en-GB.com_attachments.ini</language>
+		<language tag="en-GB">admin/language/en-GB/en-GB.com_attachments.help.ini</language>
+		<language tag="el-GR">admin/language/el-GR/el-GR.com_attachments.sys.ini</language>
+		<language tag="el-GR">admin/language/el-GR/el-GR.com_attachments.ini</language>
+		<language tag="fr-FR">admin/language/fr-FR/fr-FR.com_attachments.sys.ini</language>
+		<language tag="fr-FR">admin/language/fr-FR/fr-FR.com_attachments.ini</language>
+        <language tag="pt-BR">admin/language/pt-BR/pt-BR.com_attachments.sys.ini</language>
+        <language tag="pt-BR">admin/language/pt-BR/pt-BR.com_attachments.ini</language>
+	</languages>
+    </administration>
+
+    <media destination="com_attachments" folder="media">
+       <filename>index.html</filename>
+       <filename>css/index.html</filename>
+       <filename>css/add_attachment_button.css</filename>
+       <filename>css/add_attachment_button_rtl.css</filename>
+       <filename>css/attachments_admin.css</filename>
+       <filename>css/attachments_admin_dark.css</filename>
+       <filename>css/attachments_admin_form.css</filename>
+       <filename>css/attachments_admin_form_dark.css</filename>
+       <filename>css/attachments_admin_form_rtl.css</filename>
+       <filename>css/attachments_admin_rtl.css</filename>
+       <filename>css/attachments_admin_utils.css</filename>
+       <filename>css/attachments_admin_utils_rtl.css</filename>
+       <filename>css/attachments_frontend_form.css</filename>
+       <filename>css/attachments_frontend_form_rtl.css</filename>
+       <filename>css/attachments_hide.css</filename>
+       <filename>css/attachments_help.css</filename>
+       <filename>css/attachments_list.css</filename>
+       <filename>css/attachments_list_dark.css</filename>
+       <filename>css/attachments_list_rtl.css</filename>
+       <filename>css/attachments_quickicon.css</filename>
+       <filename>css/insert_attachments_token_button.css</filename>
+       <filename>css/insert_attachments_token_button_rtl.css</filename>
+       <filename>images/index.html</filename>
+       <filename>images/add_attachment.gif</filename>
+       <filename>images/add_attachment_button.png</filename>
+       <filename>images/add_attachment_button_rtl.png</filename>
+       <filename>images/add_attachment_button_small.png</filename>
+       <filename>images/add_attachment_button_small_rtl.png</filename>
+       <filename>images/attachment.gif</filename>
+       <filename>images/attachments.png</filename>
+       <filename>images/attachments_help_logo32.png</filename>
+       <filename>images/attachments_logo32.png</filename>
+       <filename>images/attachments_logo48.png</filename>
+       <filename>images/attachments_utils32.png</filename>
+       <filename>images/delete.gif</filename>
+       <filename>images/download.gif</filename>
+       <filename>images/insert_attachments_token_button.png</filename>
+       <filename>images/insert_attachments_token_button_rtl.png</filename>
+       <filename>images/insert_attachments_token_button_small.png</filename>
+       <filename>images/insert_attachments_token_button_small_rtl.png</filename>
+       <filename>images/pencil.gif</filename>
+       <filename>images/update.gif</filename>
+       <filename>js/index.html</filename>
+       <filename>js/attachments_caching.js</filename>
+       <filename>js/attachments_refresh.js</filename>
+       <folder>images/file_icons</folder>
+       <folder>images/help</folder>
+    </media>
+
+    <!-- Install the package language file this way since it is not clear how to install it directly with the package installer -->
+    <languages>
+		<language tag="en-GB">site/language/en-GB/en-GB.com_attachments.ini</language>
+    	<language tag="el-GR">site/language/el-GR/el-GR.com_attachments.ini</language>
+		<language tag="fr-FR">site/language/fr-FR/fr-FR.com_attachments.ini</language>
+	</languages>
+
+</extension>

--- a/packages/attachments_component/language/pt-BR/pt-BR.com_attachments.sys.ini
+++ b/packages/attachments_component/language/pt-BR/pt-BR.com_attachments.sys.ini
@@ -1,0 +1,13 @@
+; Tradução para Português do Brasil do componente Gestor de Anexos
+ATTACH_ALL_ATTACHMENTS_PLUGINS_ENABLED="NOTA: Todos os plugins de anexos acima foram ativados!"
+ATTACH_ATTACHMENTS="Anexos"
+ATTACH_ATTACHMENTS_COMPONENT_DESCRIPTION="Componente Gestor de Anexos"
+ATTACH_ATTACHMENTS_COMPONENT_SUCCESSFULLY_INSTALLED="Componente Gestor de Anexos instalado com sucesso!"
+ATTACH_ATTACHMENTS_COMPONENT_SUCCESSFULLY_UPGRADED="Componente Gestor de Anexos atualizado com sucesso!"
+ATTACH_ATTACHMENTS_ONLY_WORKS_FOR_VERSION_S_UP="A extensão 'Gestor de Anexos' funciona apenas para Joomla versão %s ou superior!"
+ATTACH_ENABLED_ATTACHMENTS_PLUGIN_S=" -- Plugin de anexos ativado: %s"
+ATTACH_ERROR_MOVING_ATTACHMENTS_DIR="Erro ao mover o diretório 'anexos' para instalar a extensão Gestor de Anexos. Renomeie/mova temporariamente o diretório 'anexos' e tente novamente."
+ATTACH_ERROR_UINSTALL_OLD_VERSION="ERRO! Uma instalação anterior do Gestor de Anexos aparentemente falhou. Desinstale todos os plugins de anexos (são pelo menos sete: procure por 'anexo' no gerenciador de extensões). Exclua também as pastas components/com_attachments e administrator/components/com_attachments. Depois tente instalar esta versão novamente."
+ATTACH_ATTACHMENTS_ERROR_UNSUPPORTED_DB_S="ERRO! Banco de dados '%s' não é suportado para a extensão Gestor de Anexos!"
+ATTACH_INSTALLED_DEFAULT_ATTACHMENTS_ASSET_RULES="Regras de permissão padrão para novos anexos instaladas."
+ATTACH_INSTALLING_DEFAULT_ATTACHMENTS_ASSET_RULES_FAILED="Aviso: Falha ao instalar regras de permissão padrão para novos anexos."

--- a/packages/attachments_component/language/pt-BR/pt-BR.com_attachments_component.sys.ini
+++ b/packages/attachments_component/language/pt-BR/pt-BR.com_attachments_component.sys.ini
@@ -1,0 +1,6 @@
+; Tradução para Português do Brasil do componente Gestor de Anexos
+COM_ATTACHMENTS_COMPONENT="Gestor de Anexos"
+COM_ATTACHMENTS_COMPONENT_DESC="Componente para gerenciar anexos em artigos do Joomla!"
+COM_ATTACHMENTS_COMPONENT_INSTALL="Instalação do Gestor de Anexos concluída com sucesso."
+COM_ATTACHMENTS_COMPONENT_UNINSTALL="Desinstalação do Gestor de Anexos concluída com sucesso."
+COM_ATTACHMENTS_COMPONENT_UPDATE="Atualização do Gestor de Anexos concluída com sucesso."

--- a/packages/attachments_component/site/src/View/Attachments/metadata.xml
+++ b/packages/attachments_component/site/src/View/Attachments/metadata.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<metadata>
+  <view title="ATTACH_ATTACHMENTS_DO_NOT_ATTACH_TO_MENU_ITEM" hidden="true">
+  </view>
+</metadata>

--- a/packages/attachments_component/site/src/View/Update/metadata.xml
+++ b/packages/attachments_component/site/src/View/Update/metadata.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<metadata>
+  <view title="ATTACH_UPDATE_DO_NOT_ATTACH_TO_MENU_ITEM" hidden="true">
+  </view>
+</metadata>

--- a/packages/attachments_component/site/src/View/Upload/metadata.xml
+++ b/packages/attachments_component/site/src/View/Upload/metadata.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<metadata>
+  <view title="ATTACH_UPLOAD_DO_NOT_ATTACH_TO_MENU_ITEM" hidden="true">
+  </view>
+</metadata>

--- a/packages/attachments_component/site/tmpl/attachments/default.xml
+++ b/packages/attachments_component/site/tmpl/attachments/default.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<metadata>
+   <layout title="ATTACH_ATTACHMENTS_DEFAULT_LAYOUT_DO_NOT_ATTACH_TO_MENU_ITEM"  hidden="true">
+   </layout>
+</metadata>

--- a/packages/attachments_finder_plugin/attachments.xml
+++ b/packages/attachments_finder_plugin/attachments.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extension type="plugin" group="finder" method="upgrade">
+	<name>plg_finder_attachments</name>
+	<author>Jonathan M. Cameron</author>
+	<creationDate>August  1, 2025</creationDate>
+	<copyright>(C) 2007-2025 Jonathan M. Cameron. All rights reserved.</copyright>
+	<license>https://www.gnu.org/licenses/gpl-3.0.html GNU/GPL</license>
+	<authorEmail>jmcameron@jmcameron.net</authorEmail>
+	<authorUrl>https://github.com/jmcameron/attachments</authorUrl>
+	<version>4.1.6</version>
+	<description>ATTACH_ATTACHMENTS_FINDER_PLUGIN_DESCRIPTION</description>
+	<namespace path="src">JMCameron\Plugin\Finder\Attachments</namespace>
+	<files>
+		<folder plugin="attachments">services</folder>
+		<folder>src</folder>
+	</files>
+	<languages>
+		<language tag="en-GB">language/en-GB/plg_finder_attachments.ini</language>
+		<language tag="en-GB">language/en-GB/plg_finder_attachments.sys.ini</language>
+		<language tag="el-GR">language/el-GR/plg_finder_attachments.ini</language>
+		<language tag="el-GR">language/el-GR/plg_finder_attachments.sys.ini</language>
+        <language tag="pt-BR">language/pt-BR/pt-BR.plg_finder_attachments.ini</language>
+        <language tag="pt-BR">language/pt-BR/pt-BR.plg_finder_attachments.sys.ini</language>
+	</languages>
+	<config>
+		<fields name="params">
+			<fieldset name="basic" addfieldprefix="Joomla\Component\Finder\Administrator\Field">
+				<field
+					name="search_archived"
+					type="radio"
+					layout="joomla.form.field.radio.switcher"
+					label="PLG_FINDER_ATTACHMENTS_FIELD_SEARCH_ARCHIVED_LABEL"
+					description="PLG_FINDER_ATTACHMENTS_FIELD_SEARCH_ARCHIVED_DESC"
+					default="1"
+					filter="integer"
+					>
+					<option value="0">JNO</option>
+					<option value="1">JYES</option>
+				</field>
+				<field
+					name="taxonomies"
+					type="taxonomytypes"
+					label="PLG_FINDER_ATTACHMENTS_TAXONOMIES_LABEL"
+					default="type,language"
+					multiple="true"
+					>
+					<option value="language">PLG_FINDER_ATTACHMENTS_TAXONOMIES_LANGUAGE</option>
+					<option value="type">PLG_FINDER_ATTACHMENTS_TAXONOMIES_TYPE</option>
+				</field>
+			</fieldset>
+		</fields>
+	</config>
+</extension>

--- a/packages/attachments_finder_plugin/language/pt-BR/pt-BR.plg_attachments_finder_plugin.sys.ini
+++ b/packages/attachments_finder_plugin/language/pt-BR/pt-BR.plg_attachments_finder_plugin.sys.ini
@@ -1,0 +1,6 @@
+; Tradução para Português do Brasil do plugin Gestor de Anexos - Finder
+PLG_ATTACHMENTS_FINDER_PLUGIN="Gestor de Anexos - Finder"
+PLG_ATTACHMENTS_FINDER_PLUGIN_DESC="Permite pesquisar anexos nos artigos usando o Gestor de Anexos."
+PLG_ATTACHMENTS_FINDER_PLUGIN_INSTALL="Instalação do plugin Gestor de Anexos - Finder concluída com sucesso."
+PLG_ATTACHMENTS_FINDER_PLUGIN_UNINSTALL="Desinstalação do plugin Gestor de Anexos - Finder concluída com sucesso."
+PLG_ATTACHMENTS_FINDER_PLUGIN_UPDATE="Atualização do plugin Gestor de Anexos - Finder concluída com sucesso."

--- a/packages/attachments_finder_plugin/language/pt-BR/pt-BR.plg_finder_attachments.sys.ini
+++ b/packages/attachments_finder_plugin/language/pt-BR/pt-BR.plg_finder_attachments.sys.ini
@@ -1,0 +1,4 @@
+; Tradução para Português do Brasil do plugin Smart Search - Anexos
+ATTACH_ATTACHMENTS_FINDER_PLUGIN_DESCRIPTION="O plugin de busca inteligente de anexos permite pesquisar todos os nomes/URLs e descrições dos anexos."
+PLG_FINDER_ATTACHMENTS="Busca Inteligente - Anexos"
+PLG_FINDER_STATISTICS_ATTACHMENT="Anexo"

--- a/packages/attachments_for_content/attachments_for_content.xml
+++ b/packages/attachments_for_content/attachments_for_content.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension type="plugin" group="attachments" version="2.5" method="upgrade">
+    <name>plg_attachments_attachments_for_content</name>
+    <version>4.1.6</version>
+    <creationDate>August  1, 2025</creationDate>
+    <author>Jonathan M. Cameron</author>
+    <authorEmail>jmcameron@jmcameron.net</authorEmail>
+    <authorUrl>https://github.com/jmcameron/attachments</authorUrl>
+    <copyright>(C) 2007-2025 Jonathan M. Cameron. All rights reserved.</copyright>
+    <license>https://www.gnu.org/licenses/gpl-3.0.html GNU/GPL</license>
+    <description>ATTACH_ATTACHMENTS_FOR_CONTENT_PLUGIN_DESCRIPTION</description>
+    <namespace path="src">JMCameron\Plugin\Attachments\AttachmentsForContent</namespace>
+
+    <scriptfile>install.php</scriptfile>
+
+    <files>
+        <folder>src</folder>
+        <folder plugin="attachments_for_content">services</folder>
+        <filename>index.html</filename>
+        <folder>language</folder>
+</files>
+<languages>
+    <language tag="pt-BR">language/pt-BR/pt-BR.plg_attachments_attachments_for_content.ini</language>
+    <language tag="pt-BR">language/pt-BR/pt-BR.plg_attachments_attachments_for_content.sys.ini</language>
+</languages>
+    </files>
+
+</extension>

--- a/packages/attachments_for_content/language/pt-BR/pt-BR.plg_attachments_attachments_for_content.sys.ini
+++ b/packages/attachments_for_content/language/pt-BR/pt-BR.plg_attachments_attachments_for_content.sys.ini
@@ -1,0 +1,3 @@
+; Tradução para Português do Brasil do plugin Gestor de Anexos para Conteúdo
+ATTACH_ATTACHMENTS_FOR_CONTENT_PLUGIN_DESCRIPTION="O plugin Gestor de Anexos para Conteúdo permite adicionar anexos a artigos de conteúdo e descrições de categorias."
+PLG_ATTACHMENTS_ATTACHMENTS_FOR_CONTENT="Gestor de Anexos - Para Conteúdo"

--- a/packages/attachments_for_content/language/pt-BR/pt-BR.plg_attachments_for_content.sys.ini
+++ b/packages/attachments_for_content/language/pt-BR/pt-BR.plg_attachments_for_content.sys.ini
@@ -1,0 +1,6 @@
+; Tradução para Português do Brasil do plugin Gestor de Anexos para Conteúdo
+PLG_ATTACHMENTS_FOR_CONTENT="Gestor de Anexos para Conteúdo"
+PLG_ATTACHMENTS_FOR_CONTENT_DESC="Permite adicionar anexos diretamente ao conteúdo dos artigos usando o Gestor de Anexos."
+PLG_ATTACHMENTS_FOR_CONTENT_INSTALL="Instalação do plugin Gestor de Anexos para Conteúdo concluída com sucesso."
+PLG_ATTACHMENTS_FOR_CONTENT_UNINSTALL="Desinstalação do plugin Gestor de Anexos para Conteúdo concluída com sucesso."
+PLG_ATTACHMENTS_FOR_CONTENT_UPDATE="Atualização do plugin Gestor de Anexos para Conteúdo concluída com sucesso."

--- a/packages/attachments_plugin/attachments.xml
+++ b/packages/attachments_plugin/attachments.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension type="plugin" group="content" version="4.0" method="upgrade">
+    <name>plg_content_attachments</name>
+    <version>4.1.6</version>
+    <creationDate>August  1, 2025</creationDate>
+    <author>Jonathan M. Cameron</author>
+    <authorEmail>jmcameron@jmcameron.net</authorEmail>
+    <authorUrl>https://github.com/jmcameron/attachments</authorUrl>
+    <copyright>(C) 2007-2025 Jonathan M. Cameron. All rights reserved.</copyright>
+    <license>https://www.gnu.org/licenses/gpl-3.0.html GNU/GPL</license>
+    <description>ATTACH_ATTACHMENTS_PLUGIN_DESCRIPTION</description>
+    <namespace path="src">JMCameron\Plugin\Content\Attachments</namespace>
+
+    <scriptfile>install.php</scriptfile>
+
+    <files>
+        <filename>index.html</filename>
+        <folder>language</folder>
+        <folder>src</folder>
+        <folder plugin="attachments">services</folder>
+    </files>
+    <languages>
+        <language tag="pt-BR">language/pt-BR/pt-BR.plg_content_attachments.ini</language>
+        <language tag="pt-BR">language/pt-BR/pt-BR.plg_content_attachments.sys.ini</language>
+    </languages>
+    </files>
+
+</extension>

--- a/packages/attachments_plugin/language/pt-BR/pt-BR.plg_attachments_plugin.sys.ini
+++ b/packages/attachments_plugin/language/pt-BR/pt-BR.plg_attachments_plugin.sys.ini
@@ -1,0 +1,6 @@
+; Tradução para Português do Brasil do plugin principal do Gestor de Anexos
+PLG_ATTACHMENTS_PLUGIN="Gestor de Anexos - Principal"
+PLG_ATTACHMENTS_PLUGIN_DESC="Plugin principal para gerenciar anexos em artigos usando o Gestor de Anexos."
+PLG_ATTACHMENTS_PLUGIN_INSTALL="Instalação do plugin Gestor de Anexos - Principal concluída com sucesso."
+PLG_ATTACHMENTS_PLUGIN_UNINSTALL="Desinstalação do plugin Gestor de Anexos - Principal concluída com sucesso."
+PLG_ATTACHMENTS_PLUGIN_UPDATE="Atualização do plugin Gestor de Anexos - Principal concluída com sucesso."

--- a/packages/attachments_plugin/language/pt-BR/pt-BR.plg_content_attachments.sys.ini
+++ b/packages/attachments_plugin/language/pt-BR/pt-BR.plg_content_attachments.sys.ini
@@ -1,0 +1,3 @@
+; Tradução para Português do Brasil do plugin principal do Gestor de Anexos
+ATTACH_ATTACHMENTS_PLUGIN_DESCRIPTION="Plugin Gestor de Anexos: Exibe uma lista dos anexos para o artigo (ou item de conteúdo suportado)."
+PLG_CONTENT_ATTACHMENTS="Conteúdo - Anexos"

--- a/packages/attachments_plugin_framework/framework.xml
+++ b/packages/attachments_plugin_framework/framework.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension type="plugin" group="attachments" version="4.0" method="upgrade">
+    <name>plg_attachments_plugin_framework</name>
+    <version>4.1.6</version>
+    <creationDate>August  1, 2025</creationDate>
+    <author>Jonathan M. Cameron</author>
+    <authorEmail>jmcameron@jmcameron.net</authorEmail>
+    <authorUrl>https://github.com/jmcameron/attachments</authorUrl>
+    <copyright>(C) 2007-2025 Jonathan M. Cameron. All rights reserved.</copyright>
+    <license>https://www.gnu.org/licenses/gpl-3.0.html GNU/GPL</license>
+    <description>ATTACH_ATTACHMENTS_FOR_COMPONENTS_PLUGIN_FRAMEWORK_DESCRIPTION</description>
+
+    <scriptfile>install.php</scriptfile>
+
+    <namespace path="src/">JMCameron\Plugin\AttachmentsPluginFramework</namespace>
+
+    <files>
+        <filename plugin="framework">src/PlgAttachmentsFramework.php</filename>
+        <filename>src/AttachmentsPluginManager.php</filename>
+        <filename>index.html</filename>
+        <folder>language</folder>
+    </files>
+    <languages>
+        <language tag="en-GB">language/en-GB/en-GB.plg_attachments_framework.ini</language>
+        <language tag="en-GB">language/en-GB/en-GB.plg_attachments_framework.sys.ini</language>
+        <language tag="el-GR">language/el-GR/el-GR.plg_attachments_framework.ini</language>
+        <language tag="el-GR">language/el-GR/el-GR.plg_attachments_framework.sys.ini</language>
+        <language tag="fr-FR">language/fr-FR/fr-FR.plg_attachments_framework.ini</language>
+        <language tag="fr-FR">language/fr-FR/fr-FR.plg_attachments_framework.sys.ini</language>
+        <language tag="pt-BR">language/pt-BR/pt-BR.plg_attachments_framework.ini</language>
+        <language tag="pt-BR">language/pt-BR/pt-BR.plg_attachments_framework.sys.ini</language>
+    </languages>
+
+</extension>

--- a/packages/attachments_plugin_framework/language/pt-BR/pt-BR.plg_attachments_framework.sys.ini
+++ b/packages/attachments_plugin_framework/language/pt-BR/pt-BR.plg_attachments_framework.sys.ini
@@ -1,0 +1,3 @@
+; Tradução para Português do Brasil do framework do Gestor de Anexos
+ATTACH_ATTACHMENTS_FOR_COMPONENTS_PLUGIN_FRAMEWORK_DESCRIPTION="O plugin framework do Gestor de Anexos fornece a estrutura que permite adicionar anexos às partes de conteúdo de vários tipos de componentes."
+PLG_ATTACHMENTS_PLUGIN_FRAMEWORK="Gestor de Anexos - Framework de Plugin"

--- a/packages/attachments_plugin_framework/language/pt-BR/pt-BR.plg_attachments_plugin_framework.sys.ini
+++ b/packages/attachments_plugin_framework/language/pt-BR/pt-BR.plg_attachments_plugin_framework.sys.ini
@@ -1,0 +1,6 @@
+; Tradução para Português do Brasil do framework do Gestor de Anexos
+PLG_ATTACHMENTS_PLUGIN_FRAMEWORK="Framework do Gestor de Anexos"
+PLG_ATTACHMENTS_PLUGIN_FRAMEWORK_DESC="Framework para plugins do Gestor de Anexos, facilitando a integração e extensão de funcionalidades."
+PLG_ATTACHMENTS_PLUGIN_FRAMEWORK_INSTALL="Instalação do Framework do Gestor de Anexos concluída com sucesso."
+PLG_ATTACHMENTS_PLUGIN_FRAMEWORK_UNINSTALL="Desinstalação do Framework do Gestor de Anexos concluída com sucesso."
+PLG_ATTACHMENTS_PLUGIN_FRAMEWORK_UPDATE="Atualização do Framework do Gestor de Anexos concluída com sucesso."

--- a/packages/attachments_quickicon_plugin/attachments.xml
+++ b/packages/attachments_quickicon_plugin/attachments.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension type="plugin" group="quickicon" version="4.0" method="upgrade">
+	<name>plg_quickicon_attachments</name>
+    <version>4.1.6</version>
+    <creationDate>August  1, 2025</creationDate>
+	<author>Jonathan M. Cameron</author>
+	<copyright>(C) 2007-2025 Jonathan M. Cameron. All rights reserved.</copyright>
+	<license>https://www.gnu.org/licenses/gpl-3.0.html GNU/GPL</license>
+	<authorEmail>jmcameron@jmcameron.net</authorEmail>
+	<authorUrl>https://github.com/jmcameron/attachments</authorUrl>
+	<description>PLG_QUICKICON_ATTACHMENTS_XML_DESCRIPTION</description>
+    <namespace path="src">JMCameron\Plugin\Quickicon\Attachments</namespace>
+	<files>
+		<filename>index.html</filename>
+		<folder>language</folder>
+        <folder>src</folder>
+        <folder plugin="attachments">services</folder>
+	</files>
+	<languages>
+		<language tag="pt-BR">language/pt-BR/pt-BR.plg_quickicon_attachments.ini</language>
+		<language tag="pt-BR">language/pt-BR/pt-BR.plg_quickicon_attachments.sys.ini</language>
+	</languages>
+	</files>
+	<config>
+		<fields name="params">
+			<fieldset name="basic">
+				<field name="context"
+					type="text"
+					default="mod_quickicon"
+					description="PLG_QUICKICON_ATTACHMENTS_GROUP_DESC"
+					label="PLG_QUICKICON_ATTACHMENTS_GROUP_LABEL"
+				/>
+			</fieldset>
+		</fields>
+	</config>
+</extension>

--- a/packages/attachments_quickicon_plugin/language/pt-BR/pt-BR.plg_attachments_quickicon_plugin.sys.ini
+++ b/packages/attachments_quickicon_plugin/language/pt-BR/pt-BR.plg_attachments_quickicon_plugin.sys.ini
@@ -1,0 +1,6 @@
+; Tradução para Português do Brasil do plugin Quickicon do Gestor de Anexos
+PLG_ATTACHMENTS_QUICKICON_PLUGIN="Gestor de Anexos - Quickicon"
+PLG_ATTACHMENTS_QUICKICON_PLUGIN_DESC="Adiciona um ícone rápido para acesso ao Gestor de Anexos no painel administrativo."
+PLG_ATTACHMENTS_QUICKICON_PLUGIN_INSTALL="Instalação do plugin Gestor de Anexos - Quickicon concluída com sucesso."
+PLG_ATTACHMENTS_QUICKICON_PLUGIN_UNINSTALL="Desinstalação do plugin Gestor de Anexos - Quickicon concluída com sucesso."
+PLG_ATTACHMENTS_QUICKICON_PLUGIN_UPDATE="Atualização do plugin Gestor de Anexos - Quickicon concluída com sucesso."

--- a/packages/attachments_quickicon_plugin/language/pt-BR/pt-BR.plg_quickicon_attachments.sys.ini
+++ b/packages/attachments_quickicon_plugin/language/pt-BR/pt-BR.plg_quickicon_attachments.sys.ini
@@ -1,0 +1,3 @@
+; Tradução para Português do Brasil do plugin Quick Icon - Anexos
+PLG_QUICKICON_ATTACHMENTS="Ícone Rápido - Anexos"
+PLG_QUICKICON_ATTACHMENTS_XML_DESCRIPTION="Gerencie os anexos para artigos, categorias e outros tipos de conteúdo."

--- a/packages/attachments_search/attachments.xml
+++ b/packages/attachments_search/attachments.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension type="plugin" group="search" version="4.0" method="upgrade">
+    <name>plg_search_attachments</name>
+    <version>4.1.6</version>
+    <creationDate>August  1, 2025</creationDate>
+    <author>Jonathan M. Cameron</author>
+    <authorEmail>jmcameron@jmcameron.net</authorEmail>
+    <authorUrl>https://github.com/jmcameron/attachments</authorUrl>
+    <copyright>(C) 2007-2025 Jonathan M. Cameron. All rights reserved.</copyright>
+    <license>https://www.gnu.org/licenses/gpl-3.0.html GNU/GPL</license>
+    <description>ATTACH_ATTACHMENTS_SEARCH_PLUGIN_DESCRIPTION</description>
+    <namespace path="src">JMCameron\Plugin\Search\Attachments</namespace>
+
+    <files>
+    <folder>src</folder>
+    <folder plugin="attachments">services</folder>
+	<filename>index.html</filename>
+	<folder>language</folder>
+    </files>
+    <languages>
+        <language tag="pt-BR">language/pt-BR/pt-BR.plg_search_attachments.ini</language>
+        <language tag="pt-BR">language/pt-BR/pt-BR.plg_search_attachments.sys.ini</language>
+    </languages>
+    </files>
+
+    <config>
+	<fields name="params">
+	    <fieldset name="basic">
+		<field name="search_limit" type="text" size="5" default="50"
+		       label="ATTACH_SEARCH_LIMIT" description="ATTACH_SEARCH_LIMIT_DESCRIPTION"/>
+	    </fieldset>
+	</fields>
+    </config>
+
+</extension>

--- a/packages/attachments_search/language/pt-BR/pt-BR.plg_attachments_search.sys.ini
+++ b/packages/attachments_search/language/pt-BR/pt-BR.plg_attachments_search.sys.ini
@@ -1,0 +1,6 @@
+; Tradução para Português do Brasil do plugin de busca do Gestor de Anexos
+PLG_ATTACHMENTS_SEARCH="Gestor de Anexos - Busca"
+PLG_ATTACHMENTS_SEARCH_DESC="Permite buscar anexos nos artigos usando o Gestor de Anexos."
+PLG_ATTACHMENTS_SEARCH_INSTALL="Instalação do plugin Gestor de Anexos - Busca concluída com sucesso."
+PLG_ATTACHMENTS_SEARCH_UNINSTALL="Desinstalação do plugin Gestor de Anexos - Busca concluída com sucesso."
+PLG_ATTACHMENTS_SEARCH_UPDATE="Atualização do plugin Gestor de Anexos - Busca concluída com sucesso."

--- a/packages/attachments_search/language/pt-BR/pt-BR.plg_search_attachments.sys.ini
+++ b/packages/attachments_search/language/pt-BR/pt-BR.plg_search_attachments.sys.ini
@@ -1,0 +1,3 @@
+; Tradução para Português do Brasil do plugin de busca de anexos
+ATTACH_ATTACHMENTS_SEARCH_PLUGIN_DESCRIPTION="O plugin de busca de anexos permite pesquisar todos os nomes/URLs e descrições dos anexos."
+PLG_SEARCH_ATTACHMENTS="Busca - Anexos"

--- a/packages/insert_attachments_id_token_btn_plugin/insert_attachments_id_token.xml
+++ b/packages/insert_attachments_id_token_btn_plugin/insert_attachments_id_token.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension type="plugin" group="editors-xtd" version="4.0" method="upgrade">
+    <name>plg_editors-xtd_insert_attachments_id_token_btn</name>
+    <version>4.1.6</version>
+    <creationDate>August  1, 2025</creationDate>
+    <author>Jonathan M. Cameron</author>
+    <copyright>(C) 2007-2025 Jonathan M. Cameron. All rights reserved.</copyright>
+    <license>https://www.gnu.org/licenses/gpl-3.0.html GNU/GPL</license>
+    <authorEmail>jmcameron@jmcameron.net</authorEmail>
+    <authorUrl>https://github.com/jmcameron/attachments</authorUrl>
+    <description>ATTACH_INSERT_ATTACHMENTS_ID_TOKEN_BUTTON_PLUGIN_DESCRIPTION</description>
+    <namespace path="src">JMCameron\Plugin\EditorsXtd\InsertAttachmentsIdToken</namespace>
+    <files>
+        <folder>src</folder>
+        <folder plugin="insert_attachments_id_token">services</folder>
+    </files>
+	<languages>
+		<language tag="en-GB">language/en-GB/en-GB.plg_editors-xtd_insert_attachments_id_token.ini</language>
+		<language tag="en-GB">language/en-GB/en-GB.plg_editors-xtd_insert_attachments_id_token.sys.ini</language>
+		<language tag="el-GR">language/el-GR/el-GR.plg_editors-xtd_insert_attachments_id_token.ini</language>
+		<language tag="el-GR">language/el-GR/el-GR.plg_editors-xtd_insert_attachments_id_token.sys.ini</language>
+		<language tag="fr-FR">language/fr-FR/fr-FR.plg_editors-xtd_insert_attachments_id_token.ini</language>
+		<language tag="fr-FR">language/fr-FR/fr-FR.plg_editors-xtd_insert_attachments_id_token.sys.ini</language>
+        <language tag="pt-BR">language/pt-BR/pt-BR.plg_editors-xtd_insert_attachments_id_token.ini</language>
+        <language tag="pt-BR">language/pt-BR/pt-BR.plg_editors-xtd_insert_attachments_id_token.sys.ini</language>
+	</languages>
+</extension>

--- a/packages/insert_attachments_id_token_btn_plugin/language/pt-BR/pt-BR.plg_insert_attachments_id_token_btn_plugin.sys.ini
+++ b/packages/insert_attachments_id_token_btn_plugin/language/pt-BR/pt-BR.plg_insert_attachments_id_token_btn_plugin.sys.ini
@@ -1,0 +1,6 @@
+; Tradução para Português do Brasil do plugin Botão Inserir Token de ID de Anexo
+PLG_INSERT_ATTACHMENTS_ID_TOKEN_BTN_PLUGIN="Botão Inserir Token de ID de Anexo"
+PLG_INSERT_ATTACHMENTS_ID_TOKEN_BTN_PLUGIN_DESC="Adiciona um botão para inserir o token de ID de anexo nos artigos usando o Gestor de Anexos."
+PLG_INSERT_ATTACHMENTS_ID_TOKEN_BTN_PLUGIN_INSTALL="Instalação do plugin Botão Inserir Token de ID de Anexo concluída com sucesso."
+PLG_INSERT_ATTACHMENTS_ID_TOKEN_BTN_PLUGIN_UNINSTALL="Desinstalação do plugin Botão Inserir Token de ID de Anexo concluída com sucesso."
+PLG_INSERT_ATTACHMENTS_ID_TOKEN_BTN_PLUGIN_UPDATE="Atualização do plugin Botão Inserir Token de ID de Anexo concluída com sucesso."

--- a/packages/insert_attachments_token_btn_plugin/insert_attachments_token.xml
+++ b/packages/insert_attachments_token_btn_plugin/insert_attachments_token.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension type="plugin" group="editors-xtd" version="4.0" method="upgrade">
+    <name>plg_editors-xtd_insert_attachments_token_btn</name>
+    <version>4.1.6</version>
+    <creationDate>August  1, 2025</creationDate>
+    <author>Jonathan M. Cameron</author>
+    <copyright>(C) 2007-2025 Jonathan M. Cameron. All rights reserved.</copyright>
+    <license>https://www.gnu.org/licenses/gpl-3.0.html GNU/GPL</license>
+    <authorEmail>jmcameron@jmcameron.net</authorEmail>
+    <authorUrl>https://github.com/jmcameron/attachments</authorUrl>
+    <description>ATTACH_INSERT_ATTACHMENTS_TOKEN_BUTTON_PLUGIN_DESCRIPTION</description>
+    <namespace path="src">JMCameron\Plugin\EditorsXtd\InsertAttachmentsToken</namespace>
+    <files>
+        <folder>src</folder>
+        <folder plugin="insert_attachments_token">services</folder>
+    </files>
+	<languages>
+		<language tag="en-GB">language/en-GB/en-GB.plg_editors-xtd_insert_attachments_token.ini</language>
+		<language tag="en-GB">language/en-GB/en-GB.plg_editors-xtd_insert_attachments_token.sys.ini</language>
+		<language tag="el-GR">language/el-GR/el-GR.plg_editors-xtd_insert_attachments_token.ini</language>
+		<language tag="el-GR">language/el-GR/el-GR.plg_editors-xtd_insert_attachments_token.sys.ini</language>
+		<language tag="fr-FR">language/fr-FR/fr-FR.plg_editors-xtd_insert_attachments_token.ini</language>
+		<language tag="fr-FR">language/fr-FR/fr-FR.plg_editors-xtd_insert_attachments_token.sys.ini</language>
+        <language tag="pt-BR">language/pt-BR/pt-BR.plg_editors-xtd_insert_attachments_token.ini</language>
+        <language tag="pt-BR">language/pt-BR/pt-BR.plg_editors-xtd_insert_attachments_token.sys.ini</language>
+	</languages>
+</extension>

--- a/packages/insert_attachments_token_btn_plugin/language/pt-BR/pt-BR.plg_editors-xtd_insert_attachments_token.sys.ini
+++ b/packages/insert_attachments_token_btn_plugin/language/pt-BR/pt-BR.plg_editors-xtd_insert_attachments_token.sys.ini
@@ -1,0 +1,3 @@
+; Tradução para Português do Brasil do plugin Botão Inserir Token de Anexo
+ATTACH_INSERT_ATTACHMENTS_TOKEN_BUTTON_PLUGIN_DESCRIPTION="O plugin de botão para inserir token de anexo adiciona um botão que permite inserir o token personalizado {attachments} ao editar artigos ou categorias."
+PLG_EDITORS-XTD_INSERT_ATTACHMENTS_TOKEN_BTN="Botão do Editor - Inserir Token de Anexos"

--- a/packages/insert_attachments_token_btn_plugin/language/pt-BR/pt-BR.plg_insert_attachments_token_btn_plugin.sys.ini
+++ b/packages/insert_attachments_token_btn_plugin/language/pt-BR/pt-BR.plg_insert_attachments_token_btn_plugin.sys.ini
@@ -1,0 +1,6 @@
+; Tradução para Português do Brasil do plugin Botão Inserir Token de Anexo
+PLG_INSERT_ATTACHMENTS_TOKEN_BTN_PLUGIN="Botão Inserir Token de Anexo"
+PLG_INSERT_ATTACHMENTS_TOKEN_BTN_PLUGIN_DESC="Adiciona um botão para inserir o token de anexo nos artigos usando o Gestor de Anexos."
+PLG_INSERT_ATTACHMENTS_TOKEN_BTN_PLUGIN_INSTALL="Instalação do plugin Botão Inserir Token de Anexo concluída com sucesso."
+PLG_INSERT_ATTACHMENTS_TOKEN_BTN_PLUGIN_UNINSTALL="Desinstalação do plugin Botão Inserir Token de Anexo concluída com sucesso."
+PLG_INSERT_ATTACHMENTS_TOKEN_BTN_PLUGIN_UPDATE="Atualização do plugin Botão Inserir Token de Anexo concluída com sucesso."

--- a/packages/show_attachments_in_editor_plugin/language/pt-BR/pt-BR.plg_show_attachments_in_editor_plugin.sys.ini
+++ b/packages/show_attachments_in_editor_plugin/language/pt-BR/pt-BR.plg_show_attachments_in_editor_plugin.sys.ini
@@ -1,0 +1,6 @@
+; Tradução para Português do Brasil do plugin Mostrar Anexos no Editor
+PLG_SHOW_ATTACHMENTS_IN_EDITOR_PLUGIN="Mostrar Anexos no Editor"
+PLG_SHOW_ATTACHMENTS_IN_EDITOR_PLUGIN_DESC="Exibe anexos diretamente no editor de artigos usando o Gestor de Anexos."
+PLG_SHOW_ATTACHMENTS_IN_EDITOR_PLUGIN_INSTALL="Instalação do plugin Mostrar Anexos no Editor concluída com sucesso."
+PLG_SHOW_ATTACHMENTS_IN_EDITOR_PLUGIN_UNINSTALL="Desinstalação do plugin Mostrar Anexos no Editor concluída com sucesso."
+PLG_SHOW_ATTACHMENTS_IN_EDITOR_PLUGIN_UPDATE="Atualização do plugin Mostrar Anexos no Editor concluída com sucesso."

--- a/packages/show_attachments_in_editor_plugin/language/pt-BR/pt-BR.plg_system_show_attachments.sys.ini
+++ b/packages/show_attachments_in_editor_plugin/language/pt-BR/pt-BR.plg_system_show_attachments.sys.ini
@@ -1,0 +1,3 @@
+; Tradução para Português do Brasil do plugin Mostrar Anexos no Editor
+ATTACH_SHOW_ATTACHMENTS_IN_EDITOR_PLUGIN_DESCRIPTION="O plugin de sistema para mostrar anexos no editor exibe a lista de anexos no editor de artigos/conteúdo."
+PLG_SYSTEM_SHOW_ATTACHMENTS_IN_EDITOR="Sistema - Mostrar anexos no editor"

--- a/packages/show_attachments_in_editor_plugin/show_attachments.xml
+++ b/packages/show_attachments_in_editor_plugin/show_attachments.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension type="plugin" group="system" version="4.0" method="upgrade">
+    <name>plg_system_show_attachments_in_editor</name>
+    <version>4.1.6</version>
+    <creationDate>August  1, 2025</creationDate>
+    <author>Jonathan M. Cameron</author>
+    <copyright>(C) 2007-2025 Jonathan M. Cameron. All rights reserved.</copyright>
+    <license>https://www.gnu.org/licenses/gpl-3.0.html GNU/GPL</license>
+    <authorEmail>jmcameron@jmcameron.net</authorEmail>
+    <authorUrl>https://github.com/jmcameron/attachments</authorUrl>
+    <description>ATTACH_SHOW_ATTACHMENTS_IN_EDITOR_PLUGIN_DESCRIPTION</description>
+    <namespace path="src">JMCameron\Plugin\System\ShowAttachments</namespace>
+
+    <files>
+	<folder>src</folder>
+	<folder plugin="show_attachments">services</folder>
+	<filename>index.html</filename>
+	<folder>language</folder>
+    </files>
+	<languages>
+		<language tag="en-GB">language/en-GB/en-GB.plg_system_show_attachments.ini</language>
+		<language tag="en-GB">language/en-GB/en-GB.plg_system_show_attachments.sys.ini</language>
+		<language tag="el-GR">language/el-GR/el-GR.plg_system_show_attachments.ini</language>
+		<language tag="el-GR">language/el-GR/el-GR.plg_system_show_attachments.sys.ini</language>
+		<language tag="fr-FR">language/fr-FR/fr-FR.plg_system_show_attachments.ini</language>
+		<language tag="fr-FR">language/fr-FR/fr-FR.plg_system_show_attachments.sys.ini</language>
+        <language tag="pt-BR">language/pt-BR/pt-BR.plg_system_show_attachments.ini</language>
+        <language tag="pt-BR">language/pt-BR/pt-BR.plg_system_show_attachments.sys.ini</language>
+	</languages>
+
+</extension>

--- a/pkg_attachments.xml
+++ b/pkg_attachments.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<extension type="package" version="4.0" method="upgrade">
+    <name>pkg_attachments</name>
+    <packagename>attachments</packagename>
+    <version>4.1.6</version>
+    <creationDate>August  1, 2025</creationDate>
+    <copyright>(C) 2007-2025 Jonathan M. Cameron. All rights reserved.</copyright>
+    <license>https://www.gnu.org/licenses/gpl-3.0.html GNU/GPL</license>
+    <author>Jonathan M. Cameron</author>
+    <authorEmail>jmcameron@jmcameron.net</authorEmail>
+    <authorUrl>https://github.com/jmcameron/attachments</authorUrl>
+    <packager>Jonathan M. Cameron</packager>
+    <packagerurl>https://github.com/jmcameron/attachments</packagerurl>
+    <description>ATTACH_PACKAGE_ATTACHMENTS_FOR_JOOMLA_40PLUS</description>
+
+    <scriptfile>install.attachments.php</scriptfile>
+
+    <files folder="packages">
+        <file type="plugin" id="attachments" group="content">attachments_plugin.zip</file>
+        <file type="plugin" id="attachments" group="search">attachments_search.zip</file>
+        <file type="plugin" id="framework" group="attachments">attachments_plugin_framework.zip</file>
+        <file type="plugin" id="attachments_for_content" group="attachments">attachments_for_content.zip</file>
+        <file type="plugin" id="show_attachments" group="system">show_attachments_in_editor_plugin.zip</file>
+        <file type="plugin" id="add_attachment"	 group="editors-xtd">add_attachment_btn_plugin.zip</file>
+        <file type="plugin" id="insert_attachments_id_token" group="editors-xtd">insert_attachments_id_token_btn_plugin.zip</file>
+        <file type="plugin" id="insert_attachments_token" group="editors-xtd">insert_attachments_token_btn_plugin.zip</file>
+        <file type="plugin" id="attachments" group="quickicon">attachments_quickicon_plugin.zip</file>
+        <file type="plugin" id="attachments" group="finder">attachments_finder_plugin.zip</file>
+
+        <!-- Attachments Component enables all plugins on first install so it should be last in this list -->
+        <file type="component" id="com_attachments">attachments_component.zip</file>
+    </files>
+    <languages>
+        <language tag="en-GB">language/en-GB/en-GB.pkg_attachments.sys.ini</language>
+        <language tag="el-GR">language/el-GR/el-GR.pkg_attachments.sys.ini</language>
+        <language tag="fr-FR">language/fr-FR/fr-FR.pkg_attachments.sys.ini</language>
+    <language tag="pt-BR">language/pt-BR/pt-BR.pkg_attachments.sys.ini</language>
+    </languages>
+
+    <updateservers>
+       <server type="extension" priority="1" name="Attachments Updates">https://raw.githubusercontent.com/jmcameron/attachments/master/pkg_attachments/update_pkg.xml</server>
+    </updateservers>
+
+</extension>


### PR DESCRIPTION
Olá!
Estou contribuindo com a tradução completa para o português do Brasil (pt-BR) de todos os plugins e componentes do Gestor de Anexos para Joomla.

Todos os arquivos .ini foram criados nas respectivas pastas [pt-BR](vscode-file://vscode-app/c:/Users/mobta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) de cada extensão.
Traduções revisadas e padronizadas para facilitar o uso por usuários brasileiros.
Caso seja necessário algum ajuste ou adequação ao padrão do projeto, estou à disposição!

Obrigado pelo excelente trabalho com a extensão.