### PR TITLE
Fixes for install scripts

### DIFF
--- a/attachments_component/install.attachments.php
+++ b/attachments_component/install.attachments.php
@@ -200,27 +200,6 @@ class com_AttachmentsInstallerScript implements InstallerScriptInterface
             return false;
         }
 
-        // If there is debris from a previous failed attempt to install Attachments, delete it
-        // NOTE: Creating custom query because using JComponentHelper::isEnabled insists on
-        //       printing a warning if the component is not installed
-        $db = Factory::getContainer()->get('DatabaseDriver');
-        $query = $db->getQuery(true);
-        $query->select('extension_id AS id, enabled');
-        $query->from('#__extensions');
-        $query->where($query->qn('type') . ' = ' . $db->quote('component'));
-        $query->where($query->qn('element') . ' = ' . $db->quote('com_attachments'));
-        $db->setQuery($query);
-        if ($db->loadResult() == 0) {
-            if (
-                Folder::exists(JPATH_ROOT . '/components/com_attachments')
-                or Folder::exists(JPATH_ROOT . '/administrator/components/com_attachments')
-            ) {
-                $msg = Text::_('ATTACH_ERROR_UINSTALL_OLD_VERSION');
-                $app->enqueueMessage($msg, 'error');
-                return false;
-            }
-        }
-
         // Temporarily move the attachments directory out of the way to avoid conflicts
         $attachdir = JPATH_ROOT . '/attachments';
         if (Folder::exists($attachdir)) {


### PR DESCRIPTION
@JLTRY I have found a piece of code that exists for over 12 years that prevents the installation of the attachments extension if the folders of the component already exist.

I actually can't think of a reason to prevent this installation from proceeding if we are not deleting any data either from the database or from the file attachments folder. However I can think of a reason that we should not prompt the user to uninstall the extension. During uninstallation of the extension the /attachments folder that holds all attachment files is deleted that could result in data loss.

I will keep this PR in draft until I finish testing all install scripts to add any more fixes that are needed.