### PR TITLE
Registry is not the correct class for storing access rights

### DIFF
--- a/attachments_component/admin/src/Helper/AttachmentsPermissions.php
+++ b/attachments_component/admin/src/Helper/AttachmentsPermissions.php
@@ -16,7 +16,6 @@ namespace JMCameron\Component\Attachments\Administrator\Helper;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
-use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\User\UserFactoryInterface;
 use Joomla\Registry\Registry;
 
@@ -48,7 +47,7 @@ class AttachmentsPermissions
             $user = Factory::getApplication()->getIdentity();
         }
 
-        $result = new CMSObject();
+        $result = new Registry(null, "");
 
         $assetName = 'com_attachments';
 


### PR DESCRIPTION
If we set
'core.edit','core.edit.state','core.edit.own' in a registry
only the core.state value is stored due to hierachical mechanism in Registry

If you first set 'core.edit' to true, it becomes $result['core']['edit'] = true. If you then set 'core.edit.state', it becomes $result['core']['edit']['state'] = true, but now $result['core']['edit'] would need to be an array, not a boolean.