### PR TITLE
Use filter_var_array instead of filter_var. Fixes importing csv files

### DIFF
--- a/attachments_component/admin/src/Helper/AttachmentsImport.php
+++ b/attachments_component/admin/src/Helper/AttachmentsImport.php
@@ -319,7 +319,7 @@ class AttachmentsImport
         $field = array();
         $header_line = fgetcsv($file);
         // Strip of the leading BOM, if present
-        $header_line = filter_var($header_line, FILTER_DEFAULT , FILTER_FLAG_STRIP_LOW | FILTER_FLAG_STRIP_HIGH);
+        $header_line = filter_var_array($header_line, FILTER_DEFAULT , FILTER_FLAG_STRIP_LOW | FILTER_FLAG_STRIP_HIGH);
         for ($i = 0; $i < count($header_line); $i++) {
             $field_name = trim(strtolower($header_line[$i]));
             if (in_array($field_name, AttachmentsImport::$field_names)) {


### PR DESCRIPTION
In a previous version of the file the preg_replace function was replaced with filter_var but the header_line is actually an array, not a string so filter_var always returns false and the code that follows fails to run.