### PR TITLE
Removed unnecessary file and its use.

### DIFF
--- a/attachments_component/media/css/attachments_quickicon.css
+++ b/attachments_component/media/css/attachments_quickicon.css
@@ -1,7 +1,0 @@
-/* Quickicon rules */
-
-div.cpanel div#plg_quickicon_attachment span {
-    margin-left: 6px;  /* force line break */
-    margin-right: 6px;
-    line-height: 115%;
-}

--- a/attachments_quickicon_plugin/src/Extension/Attachments.php
+++ b/attachments_quickicon_plugin/src/Extension/Attachments.php
@@ -85,9 +85,6 @@ class Attachments extends CMSPlugin implements SubscriberInterface
             return;
         }
 
-        // Add the CSS file
-        HTMLHelper::stylesheet('media/com_attachments/css/attachments_quickicon.css');
-
         $image = 'icon-attachment';
 
         $result = $event->getArgument('result', []);


### PR DESCRIPTION
 Joomla creates standard block for quickicon without any other CSS formating styles needed.