### PR TITLE
Fix issue for raw download after PR#178

### DIFF
--- a/attachments_component/admin/config.xml
+++ b/attachments_component/admin/config.xml
@@ -224,6 +224,13 @@
       <option value="in_same_window">ATTACH_IN_SAME_WINDOW</option>
       <option value="in_a_popup">ATTACH_IN_A_POPUP</option>
     </field>
+    <field name="show_raw_download" type="radio" default="0" layout="joomla.form.field.radio.switcher"
+           label="ATTACH_SHOW_RAW_DOWNLOAD"
+           description="ATTACH_SHOW_RAW_DOWNLOAD_DESCRIPTION"
+           showon="file_link_open_mode:in_a_popup">
+      <option value="0">JNO</option>
+      <option value="1">JYES</option>
+    </field>
     <field name="attachments_titles" type="textarea" default=""
            label="ATTACH_CUSTOM_TITLES_FOR_ATTACHMENTS_LISTS" rows="3" cols="60"
            description="ATTACH_CUSTOM_TITLES_FOR_ATTACHMENTS_LISTS_DESCRIPTION">
@@ -270,13 +277,6 @@
            description="ATTACH_DOWNLOAD_MODE_FOR_SECURE_DOWNLOADS_DESCRIPTION">
       <option value="attachment">ATTACH_ATTACHMENT</option>
       <option value="inline">ATTACH_INLINE</option>
-    </field>
-    <field name="show_raw_download" type="radio" default="0" layout="joomla.form.field.radio.switcher"
-           label="ATTACH_SHOW_RAW_DOWNLOAD"
-           description="ATTACH_SHOW_RAW_DOWNLOAD_DESCRIPTION"
-           showon="file_link_open_mode:in_a_popup">
-      <option value="0">JNO</option>
-      <option value="1">JYES</option>
     </field>
   </fieldset>
 

--- a/attachments_component/site/tmpl/attachments/default.php
+++ b/attachments_component/site/tmpl/attachments/default.php
@@ -404,6 +404,8 @@ for ($i = 0, $n = count($attachments); $i < $n; $i++) {
         $html .= '<td class="at_file_size">' . $file_size_str . '</td>';
     }
     if ($this->show_raw_download &&  $show_in_modal) {
+        // avoid beeing scanned by javascript it is not a modal link
+        $a_class = 'at_icon';
         $url = Route::_($base_url .
                         "index.php?option=com_attachments&task=download&id=" .
                         (int)$attachment->id . "&raw=1");


### PR DESCRIPTION
keep as it is the link for downloading attachments (optional visible if show_raw_download) 
move parameter in advanced tab