### PR TITLE
Error when creating a new attachment

### DIFF
--- a/attachments_component/admin/tmpl/add/default.php
+++ b/attachments_component/admin/tmpl/add/default.php
@@ -47,6 +47,7 @@ if (!in_array($editor, $exceptions)) {
     $alt_parent_html .= '<div id="attachmentsPotentialParents">';
     $alt_parent_html .= '<p>';
 
+    $lang = $app->getLanguage();
     // For normal LTR, put the label on the left
     if (!$lang->isRTL()) {
         $alt_parent_html .= '<span>' . Text::_('ATTACH_ADD_ATTACHMENT_TO') . '</span> ';


### PR DESCRIPTION
$lang is not defined with joomla_6.10 in add template
Fix issue #198 